### PR TITLE
Make dcat:inSeries and dcat:accessService as arrays

### DIFF
--- a/data/schemas/dataset.json
+++ b/data/schemas/dataset.json
@@ -537,7 +537,7 @@
                 "array",
                 "null"
             ],
-            "itams": {
+            "items": {
                 "type": "string"
             },
             "description": "Reference to the dataset series this dataset is integrated into."

--- a/data/schemas/dataset.json
+++ b/data/schemas/dataset.json
@@ -533,7 +533,13 @@
         },
         "dcat:inSeries": {
             "title": "In dataset series",
-            "type": "string",
+            "type": [
+                "array",
+                "null"
+            ],
+            "itams": {
+                "type": "string"
+            },
             "description": "Reference to the dataset series this dataset is integrated into."
         },
         "dct:replaces": {
@@ -705,7 +711,13 @@
                     },
                     "dcat:accessService": {
                         "title": "Access service",
-                        "type": "string",
+                        "type": [
+                            "array",
+                            "null"
+                        ],
+                        "items": {
+                            "type": "string"
+                        },
                         "description": "Reference to data services used to provide access to the data."
                     }
                 }


### PR DESCRIPTION
I looked in the data and apparently no entry has those two elements yet. Merging this should then pose no validity issues. New instances will be automatically created with arrays from the form.