### PR TITLE
External catalogs refactor

### DIFF
--- a/data/raw/datasets/00d5f3a2-8387-432b-8f46-b49c3eb018ea.json
+++ b/data/raw/datasets/00d5f3a2-8387-432b-8f46-b49c3eb018ea.json
@@ -14,7 +14,7 @@
   },
   "dct:accessRights": "RESTRICTED",
   "dct:issued": "2020-01-01",
-  "dct:publisher": "BLW-OFAG-UFAG",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:name": "AV MAF, GRKDT",
     "schema:email": "maf@blw.admin.ch"
@@ -25,8 +25,8 @@
     "meine-agrardaten-freigabe",
     "MAF",
     "control-organization",
-	"contribution-jear",
-	"registration-data"
+    "contribution-jear",
+    "registration-data"
   ],
   "dct:accrualPeriodicity": "ANNUAL",
   "dct:modified": "2025-03-25",
@@ -44,19 +44,13 @@
   "foaf:page": [
     {
       "alias": "PDF: MAF-Verfügbare Datenpakete",
-	  "uri": "https://backend.blw.admin.ch/fileservice/sdweb-docs-prod-blwch-files/files/2024/08/28/3106f5f5-1bcb-4b25-a78a-75c712f2491f.pdf"
+      "uri": "https://backend.blw.admin.ch/fileservice/sdweb-docs-prod-blwch-files/files/2024/08/28/3106f5f5-1bcb-4b25-a78a-75c712f2491f.pdf"
     }
   ],
   "adms:status": "published",
   "bv:classification": "none",
   "bv:personalData": "personalData",
   "bv:typeOfData": "thematicData",
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": false
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "dcat:theme": [
     "agriculture"
   ],
@@ -67,41 +61,42 @@
   "dcat:distribution": [
     {
       "dct:identifier": "6d5bba21-952c-494f-81b8-b959a970ad77",
-	  "dct:title": {
-		"de": "Anmeldungen für Direktzahlungsprogramme zu einem Betrieb in der Schweizer Landwirtschaft",
-		"fr": "Inscription aux programmes de paiements directs pour une exploitation agricole suisse",
-		"it": "Iscrizioni per programmi di pagamenti diretti per un'azienda nell'agricoltura svizzera",
-		"en": "Registrations for direct payment programmes for a company in Swiss agriculture"
-	  },
-	  "dct:description": {
-		"de": "Dieses Datenpaket enthält die Anmeldedaten für die Direktzahlungsprogramme, für den Ökologischen Leistungsnachweis (ÖLN) sowie die Kontrollstelle. Dieses Dataset entspricht dem Datenpaket A01 \"Anmeldedaten\" aus dem MAF PDF-Katalog. Das Dataset enthält die Anmeldungen aus dem Vorjahr mit Angabe des Beitragsjahres.",
-		"fr": "Ce paquet de données contient les données d'inscription aux programmes de paiements directs, aux prestations écologiques requises (PER) ainsi qu'à l'organisme de contrôle. L'ensemble de données contient les inscriptions de l'année précédente avec indication de l'année de contribution.",
-		"it": "Questo pacchetto di dati contiene i dati di registrazione per i programmi di pagamento diretto, per le esigenze ecologiche e per l'organo di controllo. Il set di dati contiene le registrazioni dell'anno precedente con l'indicazione dell'anno di contribuzione.",
-		"en": "This data package contains the registration data for the direct payment programmes, for the proof of ecological performance and for the control body. The dataset contains the registrations from the previous year with an indication of the contribution year."
-	  },
+      "dct:title": {
+        "de": "Anmeldungen für Direktzahlungsprogramme zu einem Betrieb in der Schweizer Landwirtschaft",
+        "fr": "Inscription aux programmes de paiements directs pour une exploitation agricole suisse",
+        "it": "Iscrizioni per programmi di pagamenti diretti per un'azienda nell'agricoltura svizzera",
+        "en": "Registrations for direct payment programmes for a company in Swiss agriculture"
+      },
+      "dct:description": {
+        "de": "Dieses Datenpaket enthält die Anmeldedaten für die Direktzahlungsprogramme, für den Ökologischen Leistungsnachweis (ÖLN) sowie die Kontrollstelle. Dieses Dataset entspricht dem Datenpaket A01 \"Anmeldedaten\" aus dem MAF PDF-Katalog. Das Dataset enthält die Anmeldungen aus dem Vorjahr mit Angabe des Beitragsjahres.",
+        "fr": "Ce paquet de données contient les données d'inscription aux programmes de paiements directs, aux prestations écologiques requises (PER) ainsi qu'à l'organisme de contrôle. L'ensemble de données contient les inscriptions de l'année précédente avec indication de l'année de contribution.",
+        "it": "Questo pacchetto di dati contiene i dati di registrazione per i programmi di pagamento diretto, per le esigenze ecologiche e per l'organo di controllo. Il set di dati contiene le registrazioni dell'anno precedente con l'indicazione dell'anno di contribuzione.",
+        "en": "This data package contains the registration data for the direct payment programmes, for the proof of ecological performance and for the control body. The dataset contains the registrations from the previous year with an indication of the contribution year."
+      },
       "adms:status": "published",
       "dct:modified": "2025-03-25",
       "dcat:accessURL": "https://www.blw.admin.ch/de/meine-agrardatenfreigabe",
       "dct:format": "CSV"
     },
-	{
+    {
       "dct:identifier": "abeb3c73-9924-4898-bfa4-258d589639e3",
-	  "dct:title": {
-		"de": "Anmeldungen für Direktzahlungsprogramme zu einem Betrieb in der Schweizer Landwirtschaft - Provisorische Daten.",
-		"fr": "Inscription aux programmes de paiements directs pour une exploitation agricole suisse - données provisoires.",
-		"it": "Iscrizioni per programmi di pagamenti diretti per un'azienda nell'agricoltura svizzera - dati provvisori",
-		"en": "Registrations for direct payment programmes for a company in Swiss agriculture - provisional data"
-	  },
-	  "dct:description": {
-		"de": "Dieses Datenpaket enthält die Anmeldedaten für die Direktzahlungsprogramme, für den Ökologischen Leistungsnachweis (ÖLN) sowie die Kontrollstelle. Das Dataset mit \"provisorischen Daten\" enthält Angaben zu Anmeldungen aus dem laufenden Kalenderjahr mit Angabe des Beitragsjahres.",
-		"fr": "Ce paquet de données contient les données d'inscription aux programmes de paiements directs, aux prestations écologiques requises (PER) ainsi qu'à l'organisme de contrôle. L'ensemble de données avec « données provisoires » contient des informations sur les inscriptions de l'année civile en cours avec indication de l'année de contribution.",
-		"it": "Questo pacchetto di dati contiene i dati di registrazione per i programmi di pagamento diretto, per le esigenze ecologiche e per l'organo di controllo. Il set di dati con \"dati provvisori\" contiene informazioni sulle registrazioni dell'anno solare in corso con l'indicazione dell'anno di contribuzione.",
-		"en": "This data package contains the registration data for the direct payment programmes, for the proof of ecological performance and for the control body. The dataset with \"provisional data\" contains information on registrations from the current calendar year with an indication of the contribution year."
-	  },
+      "dct:title": {
+        "de": "Anmeldungen für Direktzahlungsprogramme zu einem Betrieb in der Schweizer Landwirtschaft - Provisorische Daten.",
+        "fr": "Inscription aux programmes de paiements directs pour une exploitation agricole suisse - données provisoires.",
+        "it": "Iscrizioni per programmi di pagamenti diretti per un'azienda nell'agricoltura svizzera - dati provvisori",
+        "en": "Registrations for direct payment programmes for a company in Swiss agriculture - provisional data"
+      },
+      "dct:description": {
+        "de": "Dieses Datenpaket enthält die Anmeldedaten für die Direktzahlungsprogramme, für den Ökologischen Leistungsnachweis (ÖLN) sowie die Kontrollstelle. Das Dataset mit \"provisorischen Daten\" enthält Angaben zu Anmeldungen aus dem laufenden Kalenderjahr mit Angabe des Beitragsjahres.",
+        "fr": "Ce paquet de données contient les données d'inscription aux programmes de paiements directs, aux prestations écologiques requises (PER) ainsi qu'à l'organisme de contrôle. L'ensemble de données avec « données provisoires » contient des informations sur les inscriptions de l'année civile en cours avec indication de l'année de contribution.",
+        "it": "Questo pacchetto di dati contiene i dati di registrazione per i programmi di pagamento diretto, per le esigenze ecologiche e per l'organo di controllo. Il set di dati con \"dati provvisori\" contiene informazioni sulle registrazioni dell'anno solare in corso con l'indicazione dell'anno di contribuzione.",
+        "en": "This data package contains the registration data for the direct payment programmes, for the proof of ecological performance and for the control body. The dataset with \"provisional data\" contains information on registrations from the current calendar year with an indication of the contribution year."
+      },
       "adms:status": "published",
       "dct:modified": "2025-03-25",
       "dcat:accessURL": "https://www.blw.admin.ch/de/meine-agrardatenfreigabe",
       "dct:format": "CSV"
     }
-  ]
+  ],
+  "bv:externalCatalogs": null
 }

--- a/data/raw/datasets/039e1df3-fd67-45f4-9692-1c9b0e97c8f3.json
+++ b/data/raw/datasets/039e1df3-fd67-45f4-9692-1c9b0e97c8f3.json
@@ -13,7 +13,7 @@
     "it": "Indice dei prezzi mensili di latticini selezionati a livello della catena del valore commercio all'ingrosso/trasformazione"
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "marktanalysen@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft, Fachbereich Marktanalysen"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "5a482bdf-7152-427e-9300-7fde7472f671"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "market-data",
@@ -78,5 +71,11 @@
   "dct:temporal": {
     "dcat:start_date": "2010-01-01",
     "dcat:end_date": "2024-12-01"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "5a482bdf-7152-427e-9300-7fde7472f671"
+    }
+  ]
 }

--- a/data/raw/datasets/06c8da71-ba0c-4226-bd17-4333c5581363.json
+++ b/data/raw/datasets/06c8da71-ba0c-4226-bd17-4333c5581363.json
@@ -13,7 +13,7 @@
     "it": "Il set di dati «Zone declive Dilavamento» serve per determinare le superfici su cui vanno adottate misure per la riduzione del dilavamento. Le prescrizioni concernenti le misure per la riduzione del dilavamento si basano sulle esigenze relative alla PER secondo l’allegato 1 numero 6.1a.4 OPD e sulle istruzioni del servizio d’omologazione dei prodotti fitosanitari dell’Ufficio federale della sicurezza alimentare e di veterinaria concernenti misure per la riduzione dei rischi nell’utilizzo di prodotti fitosanitari. I calcoli sono stati effettuati secondo criteri unitari per tutta la Svizzera. La produzione si basa sul modello digitale di elevazione DHM25 (dimensione maglia 25m) di swisstopo. Sono state distinte le seguenti classi di inclinazione del pendio: <=2 per cento; >2 per cento."
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "info@blw.admin.ch",
     "schema:name": "info@blw.admin.ch"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "48a5f275-4046-46a9-bba5-ed7a60ca3393"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "land-use",
@@ -139,6 +132,12 @@
       },
       "dct:license": "terms_by",
       "schema:comment": "ID for this distribution on opendata.swiss: a496952f-b1b9-4289-8bfd-bd080abf1932"
+    }
+  ],
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "48a5f275-4046-46a9-bba5-ed7a60ca3393"
     }
   ]
 }

--- a/data/raw/datasets/0889be91-cab7-4f6a-a692-7ca2a1a222e4.json
+++ b/data/raw/datasets/0889be91-cab7-4f6a-a692-7ca2a1a222e4.json
@@ -13,7 +13,7 @@
     "it": "Carta del rischio di erosione dei terreni coltivi, perdita di suolo media sul lungo periodo, espressa in tonnellate per ettaro e anno (Ufficio federale dell’agricoltura) Carta del rischio di erosione dei terreni coltivi della Svizzera realizzata con un reticolo a celle di 2x2 metri sulla base di SwissALTI3D e dei dati cantonali sulle superfici riguardanti i terreni coltivi (stato 2021). La carta riporta la potenziale perdita di suolo media sul lungo periodo, espressa in tonnellate per ettaro e anno, calcolata sulla base del maggese nero (erosione che potrebbe teoricamente verificarsi, se il suolo venisse lasciato permanentemente senza vegetazione). Le tonalità verdi si riferiscono a un ridotto rischio di erosione, quelle gialle a un rischio medio e quelle rosse a un rischio elevato. I valori calcolati nel modello sono sempre più alti di quelli riscontrabili nella realtà (di un coefficiente 10 circa), poiché la lavorazione e la gestione del suolo (coefficiente C) non sono state tenute in considerazione, bensì figurano come costante con il valore 1 nel calcolo. Il calcolo del rischio di erosione con algoritmi a flusso multiplo consente di rappresentare la struttura del terreno in maniera dettagliata (p.es. l’andamento di conche del terreno o di versanti trasversali con declività notevoli) e quindi anche di riconoscere il rischio di erosione del talweg, rappresentato dettagliatamente nella carta delle vie di deflusso idrico (vedi Carta delle vie di deflusso idrico). I blocchi di particelle costituiscono la base di calcolo spaziale (vedi Carta dei blocchi di particelle)."
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "info@blw.admin.ch",
     "schema:name": "info@blw.admin.ch"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "e1a93f10-8007-4ef6-b5a9-3c617ed29c32"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "soil-erosion",
@@ -139,6 +132,12 @@
       },
       "dct:license": "terms_by",
       "schema:comment": "ID for this distribution on opendata.swiss: 6b63eeaf-14da-4ad3-9739-b5e4e5d44f2a"
+    }
+  ],
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "e1a93f10-8007-4ef6-b5a9-3c617ed29c32"
     }
   ]
 }

--- a/data/raw/datasets/0a5649ab-4d30-4617-b34b-3ff9e3d99045.json
+++ b/data/raw/datasets/0a5649ab-4d30-4617-b34b-3ff9e3d99045.json
@@ -13,7 +13,7 @@
     "it": "Carta del rischio di erosione dei terreni coltivi, categorizzazione qualitativa (Ufficio federale dell’agricoltura) Carta del rischio di erosione dei terreni coltivi della Svizzera realizzata con un reticolo a celle di 2x2 metri sulla base di SwissALTI3D e dei dati cantonali sulle superfici riguardanti i terreni coltivi (stato 2021). È riportato il potenziale rischio di erosione qualitativo. La valutazione complessiva viene classificata in uno dei tre livelli di pericolo (nessun pericolo, pericolo, pericolo elevato), senza considerare l’utilizzo o il tipo di gestione del suolo. La perdita di suolo media pluriennale è calcolata basandosi sulla Universal Soil Loss Equation (USLE)."
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "info@blw.admin.ch",
     "schema:name": "info@blw.admin.ch"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "078e0c66-26c4-4f83-a3d3-700b8c7dfa58"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "erosion",
@@ -141,6 +134,12 @@
       },
       "dct:license": "terms_by",
       "schema:comment": "ID for this distribution on opendata.swiss: dd26060a-1c61-4c88-89d3-3b5d53dbcf81"
+    }
+  ],
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "078e0c66-26c4-4f83-a3d3-700b8c7dfa58"
     }
   ]
 }

--- a/data/raw/datasets/0ad233c4-e3e0-4533-9143-e4e2305de0fd.json
+++ b/data/raw/datasets/0ad233c4-e3e0-4533-9143-e4e2305de0fd.json
@@ -13,7 +13,7 @@
     "it": "Prezzi medi mensili delle uova e di una selezione di prodotti a base di uova a livello della catena di valore ingrosso per la restorazione"
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "marktanalysen@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft, Fachbereich Marktanalysen"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "f619166d-c5c5-47ba-86a0-352235e81249"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "price",
@@ -78,5 +71,11 @@
   "dct:temporal": {
     "dcat:start_date": "2013-01-01",
     "dcat:end_date": "2024-01-01"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "f619166d-c5c5-47ba-86a0-352235e81249"
+    }
+  ]
 }

--- a/data/raw/datasets/0ad73812-5afd-4a08-811b-eb785c3e7032.json
+++ b/data/raw/datasets/0ad73812-5afd-4a08-811b-eb785c3e7032.json
@@ -13,7 +13,7 @@
     "it": ""
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "alessandro.rossi@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "f10fc517-043a-449d-9e0b-3aaf51d144b5"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [],
   "dcat:theme": [
@@ -114,5 +107,11 @@
   "dct:temporal": {
     "dcat:start_date": "1990-01-01",
     "dcat:end_date": "2015-12-31"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "f10fc517-043a-449d-9e0b-3aaf51d144b5"
+    }
+  ]
 }

--- a/data/raw/datasets/0e5b02d8-877a-49e6-9d48-613ed8143d95.json
+++ b/data/raw/datasets/0e5b02d8-877a-49e6-9d48-613ed8143d95.json
@@ -1,8 +1,5 @@
 {
   "dct:identifier": "0e5b02d8-877a-49e6-9d48-613ed8143d95",
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "dct:issued": "",
   "dct:modified": "",
   "dct:temporal": {
@@ -11,7 +8,6 @@
   },
   "bv:abrogation": "",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": false
-  }
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
+  "bv:externalCatalogs": null
 }

--- a/data/raw/datasets/0fb36c61-a2c7-4cb7-8168-3f4bd9bbd167.json
+++ b/data/raw/datasets/0fb36c61-a2c7-4cb7-8168-3f4bd9bbd167.json
@@ -13,7 +13,7 @@
     "it": ""
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "alessandro.rossi@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "d5122fa9-d100-4d60-b204-95742718b3ce"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [],
   "dcat:theme": [
@@ -114,5 +107,11 @@
   "dct:temporal": {
     "dcat:start_date": "1999-01-01",
     "dcat:end_date": "2015-12-31"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "d5122fa9-d100-4d60-b204-95742718b3ce"
+    }
+  ]
 }

--- a/data/raw/datasets/0fb4574d-48e0-45db-989b-5692683311ef.json
+++ b/data/raw/datasets/0fb4574d-48e0-45db-989b-5692683311ef.json
@@ -14,7 +14,7 @@
   },
   "dct:accessRights": "RESTRICTED",
   "dct:issued": "2020-01-01",
-  "dct:publisher": "BLW-OFAG-UFAG",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:name": "AV MAF, GRKDT",
     "schema:email": "maf@blw.admin.ch"
@@ -25,14 +25,14 @@
     "meine-agrardaten-freigabe",
     "MAF",
     "operational-data",
-	"register-data",
-	"operator",
-	"BUR",
-	"UID",
-	"animal-owner",
-	"legal-form",
-	"TVD",
-	"business-relationships"
+    "register-data",
+    "operator",
+    "BUR",
+    "UID",
+    "animal-owner",
+    "legal-form",
+    "TVD",
+    "business-relationships"
   ],
   "dct:accrualPeriodicity": "WEEKLY",
   "dct:modified": "2025-03-25",
@@ -50,19 +50,13 @@
   "foaf:page": [
     {
       "alias": "PDF: MAF-Verfügbare Datenpakete",
-	  "uri": "https://backend.blw.admin.ch/fileservice/sdweb-docs-prod-blwch-files/files/2024/08/28/3106f5f5-1bcb-4b25-a78a-75c712f2491f.pdf"
+      "uri": "https://backend.blw.admin.ch/fileservice/sdweb-docs-prod-blwch-files/files/2024/08/28/3106f5f5-1bcb-4b25-a78a-75c712f2491f.pdf"
     }
   ],
   "adms:status": "published",
   "bv:classification": "none",
   "bv:personalData": "personalData",
   "bv:typeOfData": "thematicData",
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": false
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "dcat:theme": [
     "agriculture"
   ],
@@ -73,22 +67,23 @@
   "dcat:distribution": [
     {
       "dct:identifier": "e37d52e2-5efc-45f4-a226-252326aac73d",
-	  "dct:title": {
-		"de": "Beziehungen zwischen Betrieben eines Bewirtschafters in der Schweizer Landwirtschaft",
-		"fr": "Relations entre les exploitations d'un exploitant dans l'agriculture suisse",
-		"it": "Relazioni tra aziende di un gestore nell'agricoltura svizzera",
-		"en": "Relationships between the businesses of a single operator in the Swiss agricultural sector"
-	  },
-	  "dct:description": {
-		"de": "Dieses Datenpaket enthält zu einem Bewirtschafter die Beziehungen von den Betrieben zu über- oder untergeordneten Betrieben. Es bildet die hierarchische Betriebsstruktur ab. Zu den Betrieben einer rechtlichen Einheit / eines Bewirtschafters sind zu Parent- und Child-Betrieben enthalten: KT_ID_B, BUR, TVD Nummer, Betriebsform. Im BLW sind auf Anfrage über die Anwendung MAF aus dem System AGIS Betriebsdaten (Person und Betrieb), Strukturdaten und Anmeldedaten zu landwirtschaftlichen Betrieben verfügbar. Zur Weitergabe der Daten müssen die Bewirtschaftenden ihre Einwilligung in der Anwendung MAF erteilen. Dieses Dataset entspricht dem Datenpaket R03 \"Beziehungen_Betrieb\" aus dem MAF PDF-Katalog.",
-		"fr": "Ce paquet de données contient les relations entre les exploitations d'un exploitant et les exploitations supérieures ou subordonnées. Il représente la structure hiérarchique de l'exploitation. Les exploitations parentes et filiales des exploitations d'une entité juridique/d'un exploitant sont incluses : KT_ID_B, BUR, numéro BDTA, forme d'exploitation. Dans le BLW, les données d'exploitation (personne et exploitation), les données structurelles et les données d'enregistrement des exploitations agricoles sont disponibles sur demande via l'application MAF du système AGIS. Pour que les données puissent être transmises, les exploitants doivent donner leur consentement dans l'application MAF. Cet ensemble de données correspond au paquet de données R03 « Relations_Exploitation » du catalogue PDF MAF.",
-		"it": "Questo pacchetto di dati contiene le relazioni delle aziende con le aziende sovraordinate o subordinate di un gestore. Rappresenta la struttura gerarchica dell'azienda. Per le aziende di un'unità giuridica / di un gestore sono incluse le aziende madri e figlie: KT_ID_B, BUR, numero BDTA, forma aziendale. Nell'UFAG, i dati aziendali (persona e azienda), i dati strutturali e i dati di registrazione delle aziende agricole sono disponibili su richiesta tramite l'applicazione MAF del sistema AGIS. Per la trasmissione dei dati, gli agricoltori devono dare il loro consenso nell'applicazione MAF. Questo set di dati corrisponde al pacchetto di dati R03 \"Beziehungen_Betrieb\" (relazioni aziendali) del catalogo PDF MAF.",
-		"en": "This data package contains the relationships between the farms and the higher-level or lower-level farms for a manager. It reflects the hierarchical farm structure. For the farms of a legal unit/manager, the following are included for parent and child farms: KT_ID_B, BUR, TVD number, farm type. Upon request, the FOAG provides the following data from the AGIS system via the MAF application: operational data (person and operation), structural data and registration data on agricultural operations. In order for the data to be passed on, the farmers must give their consent in the MAF application. This dataset corresponds to the data package R03 \"Beziehungen_Betrieb\" (relationships between operations) from the MAF PDF catalogue."
-	  },
+      "dct:title": {
+        "de": "Beziehungen zwischen Betrieben eines Bewirtschafters in der Schweizer Landwirtschaft",
+        "fr": "Relations entre les exploitations d'un exploitant dans l'agriculture suisse",
+        "it": "Relazioni tra aziende di un gestore nell'agricoltura svizzera",
+        "en": "Relationships between the businesses of a single operator in the Swiss agricultural sector"
+      },
+      "dct:description": {
+        "de": "Dieses Datenpaket enthält zu einem Bewirtschafter die Beziehungen von den Betrieben zu über- oder untergeordneten Betrieben. Es bildet die hierarchische Betriebsstruktur ab. Zu den Betrieben einer rechtlichen Einheit / eines Bewirtschafters sind zu Parent- und Child-Betrieben enthalten: KT_ID_B, BUR, TVD Nummer, Betriebsform. Im BLW sind auf Anfrage über die Anwendung MAF aus dem System AGIS Betriebsdaten (Person und Betrieb), Strukturdaten und Anmeldedaten zu landwirtschaftlichen Betrieben verfügbar. Zur Weitergabe der Daten müssen die Bewirtschaftenden ihre Einwilligung in der Anwendung MAF erteilen. Dieses Dataset entspricht dem Datenpaket R03 \"Beziehungen_Betrieb\" aus dem MAF PDF-Katalog.",
+        "fr": "Ce paquet de données contient les relations entre les exploitations d'un exploitant et les exploitations supérieures ou subordonnées. Il représente la structure hiérarchique de l'exploitation. Les exploitations parentes et filiales des exploitations d'une entité juridique/d'un exploitant sont incluses : KT_ID_B, BUR, numéro BDTA, forme d'exploitation. Dans le BLW, les données d'exploitation (personne et exploitation), les données structurelles et les données d'enregistrement des exploitations agricoles sont disponibles sur demande via l'application MAF du système AGIS. Pour que les données puissent être transmises, les exploitants doivent donner leur consentement dans l'application MAF. Cet ensemble de données correspond au paquet de données R03 « Relations_Exploitation » du catalogue PDF MAF.",
+        "it": "Questo pacchetto di dati contiene le relazioni delle aziende con le aziende sovraordinate o subordinate di un gestore. Rappresenta la struttura gerarchica dell'azienda. Per le aziende di un'unità giuridica / di un gestore sono incluse le aziende madri e figlie: KT_ID_B, BUR, numero BDTA, forma aziendale. Nell'UFAG, i dati aziendali (persona e azienda), i dati strutturali e i dati di registrazione delle aziende agricole sono disponibili su richiesta tramite l'applicazione MAF del sistema AGIS. Per la trasmissione dei dati, gli agricoltori devono dare il loro consenso nell'applicazione MAF. Questo set di dati corrisponde al pacchetto di dati R03 \"Beziehungen_Betrieb\" (relazioni aziendali) del catalogo PDF MAF.",
+        "en": "This data package contains the relationships between the farms and the higher-level or lower-level farms for a manager. It reflects the hierarchical farm structure. For the farms of a legal unit/manager, the following are included for parent and child farms: KT_ID_B, BUR, TVD number, farm type. Upon request, the FOAG provides the following data from the AGIS system via the MAF application: operational data (person and operation), structural data and registration data on agricultural operations. In order for the data to be passed on, the farmers must give their consent in the MAF application. This dataset corresponds to the data package R03 \"Beziehungen_Betrieb\" (relationships between operations) from the MAF PDF catalogue."
+      },
       "adms:status": "published",
       "dct:modified": "2025-03-25",
       "dcat:accessURL": "https://www.blw.admin.ch/de/meine-agrardatenfreigabe",
       "dct:format": "CSV"
     }
-  ]
+  ],
+  "bv:externalCatalogs": null
 }

--- a/data/raw/datasets/1260f14f-559f-4db2-97f7-66212441786a.json
+++ b/data/raw/datasets/1260f14f-559f-4db2-97f7-66212441786a.json
@@ -14,7 +14,7 @@
     "it": "Prezzi medi annui e prezzi indicativi dei mangimi al livello della produzione"
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "marktanalysen@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft, Fachbereich Marktanalysen"
@@ -26,13 +26,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "cfaa671b-dc0d-4dde-9810-413c22b0938d"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "price",
@@ -80,5 +73,11 @@
   "dct:temporal": {
     "dcat:start_date": "2010-07-01",
     "dcat:end_date": "2023-07-01"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "cfaa671b-dc0d-4dde-9810-413c22b0938d"
+    }
+  ]
 }

--- a/data/raw/datasets/12faeb21-1ea3-45d7-a1bf-1aee6dbb8249.json
+++ b/data/raw/datasets/12faeb21-1ea3-45d7-a1bf-1aee6dbb8249.json
@@ -13,7 +13,7 @@
     "it": "Volumi annuali di uova esportate e di una selezione di prodotti importati a base di uovai a livello di creazione di valore transformazione e consumi"
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "marktanalysen@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft, Fachbereich Marktanalysen"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "5ba84e07-f6dd-454b-bf8a-68dfad9c5fa1"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "quantity",
@@ -78,5 +71,11 @@
   "dct:temporal": {
     "dcat:start_date": "2002-01-01",
     "dcat:end_date": "2024-01-01"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "5ba84e07-f6dd-454b-bf8a-68dfad9c5fa1"
+    }
+  ]
 }

--- a/data/raw/datasets/13300160-9f5f-4451-bce1-546e309cab52.json
+++ b/data/raw/datasets/13300160-9f5f-4451-bce1-546e309cab52.json
@@ -13,7 +13,7 @@
     "it": ""
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "alessandro.rossi@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "db3e2225-b8ac-4f00-950a-40a294bd88c7"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [],
   "dcat:theme": [
@@ -114,5 +107,11 @@
   "dct:temporal": {
     "dcat:start_date": "2002-01-01",
     "dcat:end_date": "2015-12-31"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "db3e2225-b8ac-4f00-950a-40a294bd88c7"
+    }
+  ]
 }

--- a/data/raw/datasets/13be2b2d-7a9e-4c95-88fa-86ea022c2475.json
+++ b/data/raw/datasets/13be2b2d-7a9e-4c95-88fa-86ea022c2475.json
@@ -13,7 +13,7 @@
     "it": ""
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "alessandro.rossi@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "d3f7f978-fe6e-4cb3-8f10-9a4bf834f89f"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [],
   "dcat:theme": [
@@ -114,5 +107,11 @@
   "dct:temporal": {
     "dcat:start_date": "2002-01-01",
     "dcat:end_date": "2015-12-31"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "d3f7f978-fe6e-4cb3-8f10-9a4bf834f89f"
+    }
+  ]
 }

--- a/data/raw/datasets/13cd3427-5ddb-4d97-bab6-6be0519a6bf6.json
+++ b/data/raw/datasets/13cd3427-5ddb-4d97-bab6-6be0519a6bf6.json
@@ -13,7 +13,7 @@
     "it": "Quantile del 33 per cento a lungo termine dell'evapotraspirazione relativa (rapporto tra evapotraspirazione attuale e potenziale, ET/ETP) per la superficie agricola utile svizzera; calcolo per i periodi di vegetazione nel periodo 1980-2006 nel reticolo a celle di 500x500m."
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "info@blw.admin.ch",
     "schema:name": "info@blw.admin.ch"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "524a909d-6dae-4c34-8dfd-029b601b51fc"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "meteorology",
@@ -134,6 +127,12 @@
       },
       "dct:license": "terms_by",
       "schema:comment": "ID for this distribution on opendata.swiss: f2b32b34-8375-47ab-bef3-c428598808f7"
+    }
+  ],
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "524a909d-6dae-4c34-8dfd-029b601b51fc"
     }
   ]
 }

--- a/data/raw/datasets/14bed7be-d997-4761-b684-6a5e0724322f.json
+++ b/data/raw/datasets/14bed7be-d997-4761-b684-6a5e0724322f.json
@@ -13,7 +13,7 @@
     "it": "Volumi annuali di uove prodotte a livello della catena di valore produzione"
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "marktanalysen@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft, Fachbereich Marktanalysen"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "433f8e00-3d19-4006-a864-be80a6c3cc3d"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "quantity",
@@ -78,5 +71,11 @@
   "dct:temporal": {
     "dcat:start_date": "2001-01-01",
     "dcat:end_date": "2024-01-01"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "433f8e00-3d19-4006-a864-be80a6c3cc3d"
+    }
+  ]
 }

--- a/data/raw/datasets/15a996da-8978-4e97-b0cf-8e15deeb2c92.json
+++ b/data/raw/datasets/15a996da-8978-4e97-b0cf-8e15deeb2c92.json
@@ -13,7 +13,7 @@
     "it": "La designazione “montagna” (p.es. formaggio di montagna) può essere impiegata se le materie prime provengono dalla regione di montagna o dalla regione d'estivazione e se lì sono anche trasformate. La trasformazione può avvenire pure in Comuni il cui territorio si trova in parte nella regione di montagna o in quella d'estivazione.La trasformazione dei seguenti prodotti può avvenire anche al di fuori della regione di montagna e di quella d'estivazione: latte pronto al consumo, panna pronta al consumo, maturazione del formaggio, nonché macellazione e sezionamento degli animali. La designazione «montagna» può essere utilizzata anche nella caratterizzazione di una derrata alimentare composta da più ingredienti anche se la derrata alimentare in sé non adempie le esigenze per l'impiego della designazione «montagna». La designazione «montagna» può riferirsi esclusivamente agli ingredienti in questione (p.es. «yogurt con latte di montagna»). (RS 910.19)"
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "info@blw.admin.ch",
     "schema:name": "info@blw.admin.ch"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "9baf5a22-ddde-4723-a241-7848e8485261"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "mountain-management",
@@ -143,6 +136,12 @@
       },
       "dct:license": "terms_by",
       "schema:comment": "ID for this distribution on opendata.swiss: 0ac06dd2-f74d-4ffa-82cb-26ced46b5b71"
+    }
+  ],
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "9baf5a22-ddde-4723-a241-7848e8485261"
     }
   ]
 }

--- a/data/raw/datasets/18291692-b713-4bed-9bf5-f3294edc6e54.json
+++ b/data/raw/datasets/18291692-b713-4bed-9bf5-f3294edc6e54.json
@@ -13,7 +13,7 @@
     "it": "I quattro fogli della carta in scala 1:200 000 forniscono una valutazione d'insieme delle condizioni climatiche e delle restrizioni relative all'agricoltura, suddivise in 20 categorie. La carta intende sottolineare le differenze di rilievo relative alle possibilità di coltivazione esistenti nelle singole regioni."
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "info@blw.admin.ch",
     "schema:name": "info@blw.admin.ch"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "c69ff9d4-991c-40f3-9078-ffb9f135666d"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "cultivation-suitability",
@@ -162,6 +155,12 @@
       },
       "dct:license": "terms_by",
       "schema:comment": "ID for this distribution on opendata.swiss: 9089df4a-e2cd-41cf-92c3-a2935fb646c2"
+    }
+  ],
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "c69ff9d4-991c-40f3-9078-ffb9f135666d"
     }
   ]
 }

--- a/data/raw/datasets/19111589-d41f-4f42-b397-b8318dfb13fd.json
+++ b/data/raw/datasets/19111589-d41f-4f42-b397-b8318dfb13fd.json
@@ -27,11 +27,6 @@
   "dct:accessRights": "PUBLIC",
   "bv:classification": "none",
   "bv:personalData": "personalData",
-  "bv:i14y": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "BLW_DS_VARIETIES",
-    "dcat:accessURL": "https://www.i14y.admin.ch/catalog/datasets/BLW_DS_VARIETIES"
-  },
   "dcat:contactPoint": {
     "schema:name": "Büro für Sortenschutz",
     "schema:email": "sortenadmin@blw.admin.ch"
@@ -82,7 +77,6 @@
     }
   ],
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": false
-  }
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
+  "bv:externalCatalogs": null
 }

--- a/data/raw/datasets/19711e0b-c622-46c7-88ee-b081e1c042d4.json
+++ b/data/raw/datasets/19711e0b-c622-46c7-88ee-b081e1c042d4.json
@@ -14,7 +14,7 @@
   },
   "dct:accessRights": "RESTRICTED",
   "dct:issued": "2020-01-01",
-  "dct:publisher": "BLW-OFAG-UFAG",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:name": "AV MAF, GRKDT",
     "schema:email": "maf@blw.admin.ch"
@@ -25,9 +25,9 @@
     "meine-agrardaten-freigabe",
     "MAF",
     "deliveries",
-	"nutrient-content",
-	"fertiliser",
-	"suisse-bilanz"
+    "nutrient-content",
+    "fertiliser",
+    "suisse-bilanz"
   ],
   "dct:accrualPeriodicity": "DAILY",
   "dct:modified": "2025-03-25",
@@ -45,19 +45,13 @@
   "foaf:page": [
     {
       "alias": "PDF: MAF-Verfügbare Datenpakete",
-	  "uri": "https://backend.blw.admin.ch/fileservice/sdweb-docs-prod-blwch-files/files/2024/08/28/3106f5f5-1bcb-4b25-a78a-75c712f2491f.pdf"
+      "uri": "https://backend.blw.admin.ch/fileservice/sdweb-docs-prod-blwch-files/files/2024/08/28/3106f5f5-1bcb-4b25-a78a-75c712f2491f.pdf"
     }
   ],
   "adms:status": "published",
   "bv:classification": "none",
   "bv:personalData": "personalData",
   "bv:typeOfData": "thematicData",
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": false
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "dcat:theme": [
     "agriculture"
   ],
@@ -68,22 +62,23 @@
   "dcat:distribution": [
     {
       "dct:identifier": "b339f38f-af90-4127-bc06-b729dc4d5a41",
-	  "dct:title": {
-		"de": "Nährstofflieferungen zwischen Betrieben in der Schweizer Landwirtschaft",
-		"fr": "Livraisons de nutriments entre les exploitations agricoles suisses",
-		"it": "Scambi di sostanze nutritive tra aziende agricole in Svizzera",
-		"en": "Nutrient transfers between farms in Swiss agriculture"
-	  },
-	  "dct:description": {
-		"de": "Dieses Datenpaket enthält alle Nährstofflieferungen aus dem System \"HODUFLU\" mit dem Lieferstatus «bestätigt» aus dem laufenden Kalenderjahr und dem Vorjahr. Zu den Lieferungen wird angegeben: Flussrichtung, Tierkategorie, Produktstamm, Volumen, Gewicht, Nährstoffgehalt, Düngerart und Swiss Bilanz Kategorie. Im BLW sind auf Anfrage über die Anwendung MAF aus dem System HODUFLU Angaben zu Lieferungen zwischen landwirtschaftlichen Betrieben verfügbar. Zur Weitergabe der Daten müssen die Bewirtschaftenden ihre Einwilligung in der Anwendung MAF erteilen. Dieses Dataset entspricht dem Datenpaket H01 \"Einzellieferungen\" aus dem MAF PDF-Katalog. Das Dataset enthält die Daten vom 01.01. des Vorjahres bis zum aktuellen Datum.",
-		"fr": "Ce paquet de données contient toutes les livraisons de nutriments du système «HODUFLU» avec le statut de livraison «confirmé» de l'année civile en cours et de l'année précédente. Les informations suivantes sont indiquées pour les livraisons: direction du flux, catégorie d'animaux, base de données des produits, volume, poids, teneur en nutriments, type d'engrais et catégorie Swiss Bilanz. L'OFAG fournit sur demande des informations sur les livraisons entre exploitations agricoles via l'application MAF du système HODUFLU. Pour que les données puissent être transmises, les exploitants doivent donner leur consentement dans l'application MAF. Cet ensemble de données correspond au paquet de données H01 «Livraisons individuelles» du catalogue PDF MAF. L'ensemble de données contient les données du 01.01 de l'année précédente jusqu'à la date actuelle.",
-		"it": "Questo pacchetto di dati contiene tutte le forniture di sostanze nutritive dal sistema «HODUFLU» con lo stato di consegna «confermato» dell'anno civile in corso e dell'anno precedente. Per le consegne sono indicati: direzione del flusso, categoria di animali, scheda prodotto, volume, peso, contenuto di sostanze nutritive, tipo di fertilizzante e categoria Swiss Bilanz. Su richiesta, l'UFAG può fornire informazioni sulle consegne tra aziende agricole tramite l'applicazione MAF del sistema HODUFLU. Per la trasmissione dei dati, gli agricoltori devono dare il loro consenso nell'applicazione MAF. Questo set di dati corrisponde al pacchetto di dati H01 “Consegne individuali” del catalogo PDF MAF. Il set di dati contiene i dati dal 01.01 dell'anno precedente alla data corrente.",
-		"en": "This data set contains all nutrient deliveries from the \"HODUFLU\" system with the delivery status \"confirmed\" from the current calendar year and the previous year. The following information is provided for the deliveries: flow direction, animal category, product base, volume, weight, nutrient content, fertiliser type and Swiss balance category. Information on deliveries between agricultural holdings is available from the FOAG on request via the MAF application from the HODUFLU system. In order to pass on the data, the farmers must give their consent in the MAF application. This dataset corresponds to the data package H01 \"Einzellieferungen\" (individual deliveries) from the MAF PDF catalogue. The dataset contains the data from 01.01. of the previous year to the current date."
-	  },
+      "dct:title": {
+        "de": "Nährstofflieferungen zwischen Betrieben in der Schweizer Landwirtschaft",
+        "fr": "Livraisons de nutriments entre les exploitations agricoles suisses",
+        "it": "Scambi di sostanze nutritive tra aziende agricole in Svizzera",
+        "en": "Nutrient transfers between farms in Swiss agriculture"
+      },
+      "dct:description": {
+        "de": "Dieses Datenpaket enthält alle Nährstofflieferungen aus dem System \"HODUFLU\" mit dem Lieferstatus «bestätigt» aus dem laufenden Kalenderjahr und dem Vorjahr. Zu den Lieferungen wird angegeben: Flussrichtung, Tierkategorie, Produktstamm, Volumen, Gewicht, Nährstoffgehalt, Düngerart und Swiss Bilanz Kategorie. Im BLW sind auf Anfrage über die Anwendung MAF aus dem System HODUFLU Angaben zu Lieferungen zwischen landwirtschaftlichen Betrieben verfügbar. Zur Weitergabe der Daten müssen die Bewirtschaftenden ihre Einwilligung in der Anwendung MAF erteilen. Dieses Dataset entspricht dem Datenpaket H01 \"Einzellieferungen\" aus dem MAF PDF-Katalog. Das Dataset enthält die Daten vom 01.01. des Vorjahres bis zum aktuellen Datum.",
+        "fr": "Ce paquet de données contient toutes les livraisons de nutriments du système «HODUFLU» avec le statut de livraison «confirmé» de l'année civile en cours et de l'année précédente. Les informations suivantes sont indiquées pour les livraisons: direction du flux, catégorie d'animaux, base de données des produits, volume, poids, teneur en nutriments, type d'engrais et catégorie Swiss Bilanz. L'OFAG fournit sur demande des informations sur les livraisons entre exploitations agricoles via l'application MAF du système HODUFLU. Pour que les données puissent être transmises, les exploitants doivent donner leur consentement dans l'application MAF. Cet ensemble de données correspond au paquet de données H01 «Livraisons individuelles» du catalogue PDF MAF. L'ensemble de données contient les données du 01.01 de l'année précédente jusqu'à la date actuelle.",
+        "it": "Questo pacchetto di dati contiene tutte le forniture di sostanze nutritive dal sistema «HODUFLU» con lo stato di consegna «confermato» dell'anno civile in corso e dell'anno precedente. Per le consegne sono indicati: direzione del flusso, categoria di animali, scheda prodotto, volume, peso, contenuto di sostanze nutritive, tipo di fertilizzante e categoria Swiss Bilanz. Su richiesta, l'UFAG può fornire informazioni sulle consegne tra aziende agricole tramite l'applicazione MAF del sistema HODUFLU. Per la trasmissione dei dati, gli agricoltori devono dare il loro consenso nell'applicazione MAF. Questo set di dati corrisponde al pacchetto di dati H01 “Consegne individuali” del catalogo PDF MAF. Il set di dati contiene i dati dal 01.01 dell'anno precedente alla data corrente.",
+        "en": "This data set contains all nutrient deliveries from the \"HODUFLU\" system with the delivery status \"confirmed\" from the current calendar year and the previous year. The following information is provided for the deliveries: flow direction, animal category, product base, volume, weight, nutrient content, fertiliser type and Swiss balance category. Information on deliveries between agricultural holdings is available from the FOAG on request via the MAF application from the HODUFLU system. In order to pass on the data, the farmers must give their consent in the MAF application. This dataset corresponds to the data package H01 \"Einzellieferungen\" (individual deliveries) from the MAF PDF catalogue. The dataset contains the data from 01.01. of the previous year to the current date."
+      },
       "adms:status": "published",
       "dct:modified": "2025-03-25",
       "dcat:accessURL": "https://www.blw.admin.ch/de/meine-agrardatenfreigabe",
       "dct:format": "CSV"
     }
-  ]
+  ],
+  "bv:externalCatalogs": null
 }

--- a/data/raw/datasets/1b460b8f-ddca-4069-b744-89798658f1fd.json
+++ b/data/raw/datasets/1b460b8f-ddca-4069-b744-89798658f1fd.json
@@ -13,7 +13,7 @@
     "it": "Per saturazione idrica s'intende la presenza, oltre alle acque meteoriche, di acque estranee (di pendio o di falda). (Dettagli: carta delle attitudini dei suoli svizzeri, marzo 1980)."
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "info@blw.admin.ch",
     "schema:name": "info@blw.admin.ch"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "1122ee8a-03c9-4007-9236-74cc2e2f5ee7"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "cultivation-suitability",
@@ -161,6 +154,12 @@
       },
       "dct:license": "terms_by",
       "schema:comment": "ID for this distribution on opendata.swiss: ceecb2af-712e-453b-becf-5ff0d4b53c0c"
+    }
+  ],
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "1122ee8a-03c9-4007-9236-74cc2e2f5ee7"
     }
   ]
 }

--- a/data/raw/datasets/1bf31551-1f4d-4947-9649-8b993504bdc0.json
+++ b/data/raw/datasets/1bf31551-1f4d-4947-9649-8b993504bdc0.json
@@ -13,7 +13,7 @@
     "it": "La potenziale carta delle superfici collegate ad acque superficiali mostra, sotto forma di \"scenario del caso peggiore\" (maggese nero permanente, fasce tampone inesistenti o provvedimenti edilizi), le superfici sulle quali in caso di gestione non adatta alle caratteristiche locali vi è un rischio notevole di immissioni di sostanze nei corsi d'acqua. Funge pertanto da ausilio per una pianificazione mirata dei provvedimenti nel settore della protezione delle acque. Il modello per l'identificazione del collegamento alle acque superficiali di superfici agricole potenzialmente a rischio d'erosione si basa sulla CRE2. Il modello di collegamento alle acque superficiali consente di calcolare, per ogni cella del reticolo della CRE2, la probabilità di collegamento a un corso d'acqua. Onde passare dal collegamento potenziale alle acque superficiali a quello reale, è necessario disporre di informazioni sull'utilizzo delle superfici a rischio e su eventuali provvedimenti volti a ridurre il deflusso. Tali informazioni vanno rilevate sul campo."
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "info@blw.admin.ch",
     "schema:name": "info@blw.admin.ch"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "dda337d2-fce5-4fc7-9bec-5fd9df78939b"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "e-geoch",
@@ -142,6 +135,12 @@
       },
       "dct:license": "terms_by",
       "schema:comment": "ID for this distribution on opendata.swiss: f5929228-52db-4ba7-9347-0fbdf9db1d75"
+    }
+  ],
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "dda337d2-fce5-4fc7-9bec-5fd9df78939b"
     }
   ]
 }

--- a/data/raw/datasets/1cde0ba1-6995-4419-ba4c-15df2e7d198c.json
+++ b/data/raw/datasets/1cde0ba1-6995-4419-ba4c-15df2e7d198c.json
@@ -13,7 +13,7 @@
     "it": "Prezzi medi annui di latticini selezionati a livello della catena del valore commercio all'ingrosso/trasformazione"
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "marktanalysen@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft, Fachbereich Marktanalysen"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "ea8c7919-23cb-4e42-8355-ee8f64cc257d"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "market-data",
@@ -78,5 +71,11 @@
   "dct:temporal": {
     "dcat:start_date": "2001-01-01",
     "dcat:end_date": "2024-01-01"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "ea8c7919-23cb-4e42-8355-ee8f64cc257d"
+    }
+  ]
 }

--- a/data/raw/datasets/21d9ebef-1f05-45d1-aec5-baafb38b2813.json
+++ b/data/raw/datasets/21d9ebef-1f05-45d1-aec5-baafb38b2813.json
@@ -13,7 +13,7 @@
     "it": "Prezzi mensili per cereali panificabili, farina e prodotti da forno al livello del commercio all’ingrosso/trasformazione"
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "marktanalysen@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft, Fachbereich Marktanalysen"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "e312e906-9a9d-4d85-84e0-479c4174b4c9"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "price",
@@ -78,5 +71,11 @@
   "dct:temporal": {
     "dcat:start_date": "2016-07-01",
     "dcat:end_date": "2024-12-01"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "e312e906-9a9d-4d85-84e0-479c4174b4c9"
+    }
+  ]
 }

--- a/data/raw/datasets/242eb58f-bd2f-45ef-9c93-cfa70bb86aaf.json
+++ b/data/raw/datasets/242eb58f-bd2f-45ef-9c93-cfa70bb86aaf.json
@@ -13,7 +13,7 @@
     "it": ""
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "alessandro.rossi@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "944a7136-0ee7-4bcf-b7a6-e69ae62767d5"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [],
   "dcat:theme": [
@@ -114,5 +107,11 @@
   "dct:temporal": {
     "dcat:start_date": "2014-01-01",
     "dcat:end_date": "2015-12-31"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "944a7136-0ee7-4bcf-b7a6-e69ae62767d5"
+    }
+  ]
 }

--- a/data/raw/datasets/27590233-ed8c-40f3-a681-166d5190dc91.json
+++ b/data/raw/datasets/27590233-ed8c-40f3-a681-166d5190dc91.json
@@ -13,7 +13,7 @@
     "it": ""
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "alessandro.rossi@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "92c28034-1619-4251-a8cc-e6e534f95a27"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [],
   "dcat:theme": [
@@ -114,5 +107,11 @@
   "dct:temporal": {
     "dcat:start_date": "1999-01-01",
     "dcat:end_date": "2015-12-31"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "92c28034-1619-4251-a8cc-e6e534f95a27"
+    }
+  ]
 }

--- a/data/raw/datasets/2782594c-5809-44a0-8eea-c838e7d1366f.json
+++ b/data/raw/datasets/2782594c-5809-44a0-8eea-c838e7d1366f.json
@@ -13,7 +13,7 @@
     "it": ""
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "alessandro.rossi@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "d407a3c3-4bd1-48c4-98cb-7ab870a16fae"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [],
   "dcat:theme": [
@@ -114,5 +107,11 @@
   "dct:temporal": {
     "dcat:start_date": "1990-01-01",
     "dcat:end_date": "2015-12-31"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "d407a3c3-4bd1-48c4-98cb-7ab870a16fae"
+    }
+  ]
 }

--- a/data/raw/datasets/2a1dfa59-c0e8-4221-9fc0-52d2cb342094.json
+++ b/data/raw/datasets/2a1dfa59-c0e8-4221-9fc0-52d2cb342094.json
@@ -14,7 +14,7 @@
     "it": "Volumi annuali di carne, pordotti carnei e insaccati commercializzati a livello della catena del valore produzione"
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "marktanalysen@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft, Fachbereich Marktanalysen"
@@ -26,13 +26,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "4b7c2e6b-07e8-4310-a262-2581bda63ac1"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "quantity",
@@ -80,5 +73,11 @@
   "dct:temporal": {
     "dcat:start_date": "2017-01-01",
     "dcat:end_date": "2023-01-01"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "4b7c2e6b-07e8-4310-a262-2581bda63ac1"
+    }
+  ]
 }

--- a/data/raw/datasets/2ca2b3af-d3da-44d7-b32b-cb1dc9b02932.json
+++ b/data/raw/datasets/2ca2b3af-d3da-44d7-b32b-cb1dc9b02932.json
@@ -13,7 +13,7 @@
     "it": ""
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "alessandro.rossi@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "fcd47ce3-f07d-48b4-bdc9-63088fcf514a"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [],
   "dcat:theme": [
@@ -114,5 +107,11 @@
   "dct:temporal": {
     "dcat:start_date": "1990-01-01",
     "dcat:end_date": "2015-12-31"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "fcd47ce3-f07d-48b4-bdc9-63088fcf514a"
+    }
+  ]
 }

--- a/data/raw/datasets/2ca8997f-b58d-490c-b7bc-edc3e59102b5.json
+++ b/data/raw/datasets/2ca8997f-b58d-490c-b7bc-edc3e59102b5.json
@@ -13,7 +13,7 @@
     "it": "Analogamente alla capacità di stoccaggio idrico, occorre indicare il numero di equivalenti di cationi che il suolo può ritenere. Questi milliequivalenti sono indicati per una colonna di suolo con base di 1 cm2 e altezza corrispondente alla profondità fisiologica. Se ne ricava il numero di milliequivalenti (meq) di cationi per cm2. (Dettagli: carta delle attitudini dei suoli svizzeri, marzo 1980)."
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "info@blw.admin.ch",
     "schema:name": "info@blw.admin.ch"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "7db80be0-f3b8-45af-a616-ef4bb1191996"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "cultivation-suitability",
@@ -161,6 +154,12 @@
       },
       "dct:license": "terms_by",
       "schema:comment": "ID for this distribution on opendata.swiss: bb444b1c-23f1-4ad8-971f-2752fd4af282"
+    }
+  ],
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "7db80be0-f3b8-45af-a616-ef4bb1191996"
     }
   ]
 }

--- a/data/raw/datasets/2ea8bfa1-8bb6-45ef-bee4-3b4cba52d834.json
+++ b/data/raw/datasets/2ea8bfa1-8bb6-45ef-bee4-3b4cba52d834.json
@@ -71,5 +71,7 @@
       "dcat:accessURL": "https://www.blw.admin.ch/de/klimastrategie-landwirtschaft-und-ernaehrung-2050#%C3%9Cberpr%C3%BCfung-der-Massnahmen-und-Zielerreichung",
       "dct:format": "PowerBI Report"
     }
-  ]
+  ],
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
+  "bv:externalCatalogs": null
 }

--- a/data/raw/datasets/3100a63c-e129-4e3a-bc1e-611cbd889c19.json
+++ b/data/raw/datasets/3100a63c-e129-4e3a-bc1e-611cbd889c19.json
@@ -13,7 +13,7 @@
     "it": ""
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "alessandro.rossi@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "86a07747-ea1e-4d58-a716-1dd72f603bed"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [],
   "dcat:theme": [
@@ -114,5 +107,11 @@
   "dct:temporal": {
     "dcat:start_date": "2000-01-01",
     "dcat:end_date": "2016-12-31"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "86a07747-ea1e-4d58-a716-1dd72f603bed"
+    }
+  ]
 }

--- a/data/raw/datasets/3235b545-25a7-4ef6-a489-262d71ed60d1.json
+++ b/data/raw/datasets/3235b545-25a7-4ef6-a489-262d71ed60d1.json
@@ -13,7 +13,7 @@
     "it": ""
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "alessandro.rossi@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "e30471dd-40ed-489b-a9d6-b2baef24f859"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [],
   "dcat:theme": [
@@ -114,5 +107,11 @@
   "dct:temporal": {
     "dcat:start_date": "1990-01-01",
     "dcat:end_date": "2015-12-31"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "e30471dd-40ed-489b-a9d6-b2baef24f859"
+    }
+  ]
 }

--- a/data/raw/datasets/3749fc93-56b7-439d-a198-cc185e53278b.json
+++ b/data/raw/datasets/3749fc93-56b7-439d-a198-cc185e53278b.json
@@ -13,7 +13,7 @@
     "it": ""
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "alessandro.rossi@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "bf61558b-0a54-4f22-9d58-ed4325f9007b"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [],
   "dcat:theme": [
@@ -114,5 +107,11 @@
   "dct:temporal": {
     "dcat:start_date": "2007-01-01",
     "dcat:end_date": "2014-12-31"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "bf61558b-0a54-4f22-9d58-ed4325f9007b"
+    }
+  ]
 }

--- a/data/raw/datasets/38200f08-d086-4a8f-8a6f-ae6de5f0d4f0.json
+++ b/data/raw/datasets/38200f08-d086-4a8f-8a6f-ae6de5f0d4f0.json
@@ -13,7 +13,7 @@
     "it": "Fondi annuali disponibili e contributi versati nell'ambito delle misure di allentamento del mercato per le uova "
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "marktanalysen@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft, Fachbereich Marktanalysen"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "27629a23-2ee1-4344-990d-889c86780b01"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "market-data",
@@ -78,5 +71,11 @@
   "dct:temporal": {
     "dcat:start_date": "2001-01-01",
     "dcat:end_date": "2024-01-01"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "27629a23-2ee1-4344-990d-889c86780b01"
+    }
+  ]
 }

--- a/data/raw/datasets/3a2d8680-3bcb-47ed-a982-f46112eb3db9.json
+++ b/data/raw/datasets/3a2d8680-3bcb-47ed-a982-f46112eb3db9.json
@@ -13,7 +13,7 @@
     "it": "I quattro fogli della carta in scala 1:200 000 forniscono una valutazione d'insieme delle condizioni climatiche e delle restrizioni relative all'agricoltura, suddivise in 20 categorie. La carta intende sottolineare le differenze di rilievo relative alle possibilità di coltivazione esistenti nelle singole regioni."
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "info@blw.admin.ch",
     "schema:name": "info@blw.admin.ch"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "7fc087e8-ccc1-4cda-a99d-0dced5d72537"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "cultivation-suitability",
@@ -162,6 +155,12 @@
       },
       "dct:license": "terms_by",
       "schema:comment": "ID for this distribution on opendata.swiss: ce6d80aa-0a5d-40b6-bdd4-6143c8650cc3"
+    }
+  ],
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "7fc087e8-ccc1-4cda-a99d-0dced5d72537"
     }
   ]
 }

--- a/data/raw/datasets/3a4d63bf-574b-4318-b6af-0777485c5411.json
+++ b/data/raw/datasets/3a4d63bf-574b-4318-b6af-0777485c5411.json
@@ -13,7 +13,7 @@
     "it": "Sulla carta delle attitudini dei suoli ogni unità cartografica è dotata di un codice composto da una lettera maiuscola e da un numero. Le lettere rappresentano 25 unità fisiografiche differenti. Il numero indica diversi elementi formali dei paesaggi, ordinati in base a roccia madre, esposizione e declività. Inoltre, ogni unità cartografica contiene una o più tipologie di suolo. Le 144 unità cartografiche totali sono classificate, secondo l'attitudine del suolo, in 18 gruppi caratterizzati da colori differenti. Questa classificazione si basa essenzialmente su criteri di tipo agricolo."
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "info@blw.admin.ch",
     "schema:name": "info@blw.admin.ch"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "cf8b87c9-edac-4785-b248-34192da76723"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "cultivation-suitability",
@@ -161,6 +154,12 @@
       },
       "dct:license": "terms_by",
       "schema:comment": "ID for this distribution on opendata.swiss: caec4af2-4f5f-4595-9488-793b5aac7887"
+    }
+  ],
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "cf8b87c9-edac-4785-b248-34192da76723"
     }
   ]
 }

--- a/data/raw/datasets/3d9aaf1f-57f8-4714-a2c1-a2d544241e91.json
+++ b/data/raw/datasets/3d9aaf1f-57f8-4714-a2c1-a2d544241e91.json
@@ -14,7 +14,7 @@
     "it": "Volumi annuali di carne, pordotti carnei e insaccati commercializzati a livello della catena del valore consumo"
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "marktanalysen@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft, Fachbereich Marktanalysen"
@@ -26,13 +26,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "b8368066-995a-424d-96bc-d6993720865b"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "market-data",
@@ -80,5 +73,11 @@
   "dct:temporal": {
     "dcat:start_date": "2017-01-01",
     "dcat:end_date": "2023-01-01"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "b8368066-995a-424d-96bc-d6993720865b"
+    }
+  ]
 }

--- a/data/raw/datasets/3dc41516-bc6a-4295-9911-050173c68cee.json
+++ b/data/raw/datasets/3dc41516-bc6a-4295-9911-050173c68cee.json
@@ -13,7 +13,7 @@
     "it": ""
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "alessandro.rossi@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "a26b3c05-5d09-40db-a674-3f6054fd8672"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [],
   "dcat:theme": [
@@ -114,5 +107,11 @@
   "dct:temporal": {
     "dcat:start_date": "2002-01-01",
     "dcat:end_date": "2015-12-31"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "a26b3c05-5d09-40db-a674-3f6054fd8672"
+    }
+  ]
 }

--- a/data/raw/datasets/3e7fd49d-0d26-44fe-86a4-ac06240ea5d7.json
+++ b/data/raw/datasets/3e7fd49d-0d26-44fe-86a4-ac06240ea5d7.json
@@ -14,7 +14,7 @@
   },
   "dct:accessRights": "RESTRICTED",
   "dct:issued": "2020-01-01",
-  "dct:publisher": "BLW-OFAG-UFAG",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:name": "AV MAF, GRKDT",
     "schema:email": "maf@blw.admin.ch"
@@ -25,14 +25,14 @@
     "meine-agrardaten-freigabe",
     "MAF",
     "operational-data",
-	"register-data",
-	"operator",
-	"BUR",
-	"UID",
-	"animal-owner",
-	"legal-form",
-	"KT_ID_B",
-	"KT_ID_P"
+    "register-data",
+    "operator",
+    "BUR",
+    "UID",
+    "animal-owner",
+    "legal-form",
+    "KT_ID_B",
+    "KT_ID_P"
   ],
   "dct:accrualPeriodicity": "WEEKLY",
   "dct:modified": "2025-03-25",
@@ -50,19 +50,13 @@
   "foaf:page": [
     {
       "alias": "PDF: MAF-Verfügbare Datenpakete",
-	  "uri": "https://backend.blw.admin.ch/fileservice/sdweb-docs-prod-blwch-files/files/2024/08/28/3106f5f5-1bcb-4b25-a78a-75c712f2491f.pdf"
+      "uri": "https://backend.blw.admin.ch/fileservice/sdweb-docs-prod-blwch-files/files/2024/08/28/3106f5f5-1bcb-4b25-a78a-75c712f2491f.pdf"
     }
   ],
   "adms:status": "published",
   "bv:classification": "none",
   "bv:personalData": "personalData",
   "bv:typeOfData": "thematicData",
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": false
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "dcat:theme": [
     "agriculture"
   ],
@@ -73,22 +67,23 @@
   "dcat:distribution": [
     {
       "dct:identifier": "3fe12ab0-7d74-4b88-a9d7-662ce0bbcc87",
-	  "dct:title": {
-		"de": "Betriebsangaben zu Betrieben in der Schweizer Landwirtschaft",
-		"fr": "Données d'entreprises de l'agriculture suisse",
-		"it": "Dati aziendali relativi alle aziende agricole svizzere",
-		"en": "Information on Swiss agricultural businesses"
-	  },
-	  "dct:description": {
-		"de": "Dieses Datenpaket enthält allgemeine Informationen zu Betrieben von Tierhaltern und Bewirtschaftern, wie: Standortadresse, Koordinaten, Unternehmensnummern, Betriebsform und zum Betrieb zugeordnete Person. Im BLW sind auf Anfrage über die Anwendung MAF aus dem System AGIS Betriebsdaten (Person und Betrieb), Strukturdaten und Anmeldedaten zu landwirtschaftlichen Betrieben verfügbar. Zur Weitergabe der Daten müssen die Bewirtschaftenden ihre Einwilligung in der Anwendung MAF erteilen. Dieses Dataset entspricht dem Datenpaket R02 \"Betrieb\" aus dem MAF PDF-Katalog.",
-		"fr": "Ce paquet de données contient des informations générales sur les exploitations des éleveurs et des exploitants, telles que l'adresse du site, les coordonnées, les numéros d'entreprise, le type d'exploitation et la personne associée à l'exploitation. L'OFAG met à disposition, sur demande, des données d'exploitation (personne et exploitation), des données structurelles et des données d'enregistrement des exploitations agricoles à partir du système AGIS via l'application MAF. Pour que les données puissent être transmises, les exploitants doivent donner leur consentement dans l'application MAF. Cet ensemble de données correspond au paquet de données R02 « Exploitation » du catalogue PDF MAF.",
-		"it": "Questo pacchetto di dati contiene informazioni generali sulle aziende di allevatori e gestori, quali: indirizzo della sede, coordinate, numeri aziendali, forma aziendale e persona associata all'azienda. Su richiesta, l'UFAG mette a disposizione dati aziendali (persona e azienda), dati strutturali e dati di registrazione delle aziende agricole tramite l'applicazione MAF del sistema AGIS. Per la trasmissione dei dati, gli agricoltori devono dare il loro consenso nell'applicazione MAF. Questo set di dati corrisponde al pacchetto di dati R02 \"Azienda\" del catalogo PDF MAF.",
-		"en": "This data package contains general information on businesses run by livestock owners and farmers, such as: location address, coordinates, company numbers, type of business and person assigned to the business. In the FOAG, farm data (person and business), structural data and registration data on agricultural businesses are available on request via the MAF application from the AGIS system. Farm managers must give their consent in the MAF application for the data to be passed on. This dataset corresponds to the data package R02 \"Betrieb\" (holding) from the MAF PDF catalogue."
-	  },
+      "dct:title": {
+        "de": "Betriebsangaben zu Betrieben in der Schweizer Landwirtschaft",
+        "fr": "Données d'entreprises de l'agriculture suisse",
+        "it": "Dati aziendali relativi alle aziende agricole svizzere",
+        "en": "Information on Swiss agricultural businesses"
+      },
+      "dct:description": {
+        "de": "Dieses Datenpaket enthält allgemeine Informationen zu Betrieben von Tierhaltern und Bewirtschaftern, wie: Standortadresse, Koordinaten, Unternehmensnummern, Betriebsform und zum Betrieb zugeordnete Person. Im BLW sind auf Anfrage über die Anwendung MAF aus dem System AGIS Betriebsdaten (Person und Betrieb), Strukturdaten und Anmeldedaten zu landwirtschaftlichen Betrieben verfügbar. Zur Weitergabe der Daten müssen die Bewirtschaftenden ihre Einwilligung in der Anwendung MAF erteilen. Dieses Dataset entspricht dem Datenpaket R02 \"Betrieb\" aus dem MAF PDF-Katalog.",
+        "fr": "Ce paquet de données contient des informations générales sur les exploitations des éleveurs et des exploitants, telles que l'adresse du site, les coordonnées, les numéros d'entreprise, le type d'exploitation et la personne associée à l'exploitation. L'OFAG met à disposition, sur demande, des données d'exploitation (personne et exploitation), des données structurelles et des données d'enregistrement des exploitations agricoles à partir du système AGIS via l'application MAF. Pour que les données puissent être transmises, les exploitants doivent donner leur consentement dans l'application MAF. Cet ensemble de données correspond au paquet de données R02 « Exploitation » du catalogue PDF MAF.",
+        "it": "Questo pacchetto di dati contiene informazioni generali sulle aziende di allevatori e gestori, quali: indirizzo della sede, coordinate, numeri aziendali, forma aziendale e persona associata all'azienda. Su richiesta, l'UFAG mette a disposizione dati aziendali (persona e azienda), dati strutturali e dati di registrazione delle aziende agricole tramite l'applicazione MAF del sistema AGIS. Per la trasmissione dei dati, gli agricoltori devono dare il loro consenso nell'applicazione MAF. Questo set di dati corrisponde al pacchetto di dati R02 \"Azienda\" del catalogo PDF MAF.",
+        "en": "This data package contains general information on businesses run by livestock owners and farmers, such as: location address, coordinates, company numbers, type of business and person assigned to the business. In the FOAG, farm data (person and business), structural data and registration data on agricultural businesses are available on request via the MAF application from the AGIS system. Farm managers must give their consent in the MAF application for the data to be passed on. This dataset corresponds to the data package R02 \"Betrieb\" (holding) from the MAF PDF catalogue."
+      },
       "adms:status": "published",
       "dct:modified": "2025-03-25",
       "dcat:accessURL": "https://www.blw.admin.ch/de/meine-agrardatenfreigabe",
       "dct:format": "CSV"
     }
-  ]
+  ],
+  "bv:externalCatalogs": null
 }

--- a/data/raw/datasets/3ff52744-9fc6-423d-b0bf-91faf913291a.json
+++ b/data/raw/datasets/3ff52744-9fc6-423d-b0bf-91faf913291a.json
@@ -13,7 +13,7 @@
     "it": ""
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "alessandro.rossi@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "74ca4ec5-9df1-4e9d-beaf-80c78295862a"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [],
   "dcat:theme": [
@@ -114,5 +107,11 @@
   "dct:temporal": {
     "dcat:start_date": "2014-01-01",
     "dcat:end_date": "2015-12-31"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "74ca4ec5-9df1-4e9d-beaf-80c78295862a"
+    }
+  ]
 }

--- a/data/raw/datasets/428f6bd7-3ecf-4c95-9adc-d7d635f56449.json
+++ b/data/raw/datasets/428f6bd7-3ecf-4c95-9adc-d7d635f56449.json
@@ -13,7 +13,7 @@
     "it": "I quattro fogli della carta in scala 1:200 000 forniscono una valutazione d'insieme delle condizioni climatiche e delle restrizioni relative all'agricoltura, suddivise in 20 categorie. La carta intende sottolineare le differenze di rilievo relative alle possibilità di coltivazione esistenti nelle singole regioni."
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "info@blw.admin.ch",
     "schema:name": "info@blw.admin.ch"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "03b7b099-23f4-41aa-a441-aea3a3cdfdb4"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "cultivation-suitability",
@@ -162,6 +155,12 @@
       },
       "dct:license": "terms_by",
       "schema:comment": "ID for this distribution on opendata.swiss: 55bc3d76-13cb-414d-911b-ff86bc8d8a52"
+    }
+  ],
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "03b7b099-23f4-41aa-a441-aea3a3cdfdb4"
     }
   ]
 }

--- a/data/raw/datasets/451e6d03-9868-49fb-8c26-ebf3acc85e43.json
+++ b/data/raw/datasets/451e6d03-9868-49fb-8c26-ebf3acc85e43.json
@@ -14,7 +14,7 @@
   },
   "dct:accessRights": "RESTRICTED",
   "dct:issued": "2020-01-01",
-  "dct:publisher": "BLW-OFAG-UFAG",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:name": "AV MAF, GRKDT",
     "schema:email": "maf@blw.admin.ch"
@@ -25,10 +25,10 @@
     "meine-agrardaten-freigabe",
     "MAF",
     "structural-data",
-	"farm",
-	"animals",
-	"GVE",
-	"summering"
+    "farm",
+    "animals",
+    "GVE",
+    "summering"
   ],
   "dct:accrualPeriodicity": "ANNUAL",
   "dct:modified": "2025-03-25",
@@ -46,19 +46,13 @@
   "foaf:page": [
     {
       "alias": "PDF: MAF-Verfügbare Datenpakete",
-	  "uri": "https://backend.blw.admin.ch/fileservice/sdweb-docs-prod-blwch-files/files/2024/08/28/3106f5f5-1bcb-4b25-a78a-75c712f2491f.pdf"
+      "uri": "https://backend.blw.admin.ch/fileservice/sdweb-docs-prod-blwch-files/files/2024/08/28/3106f5f5-1bcb-4b25-a78a-75c712f2491f.pdf"
     }
   ],
   "adms:status": "published",
   "bv:classification": "none",
   "bv:personalData": "personalData",
   "bv:typeOfData": "thematicData",
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": false
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "dcat:theme": [
     "agriculture"
   ],
@@ -69,41 +63,42 @@
   "dcat:distribution": [
     {
       "dct:identifier": "01bcf7b1-a662-42ff-948f-40339a6a3b24",
-	  "dct:title": {
-		"de": "Art und Anzahl Nutztiere in Sömmerung auf einem Betrieb in der Schweizer Landwirtschaft",
-		"fr": "Type et nombre d'animaux de rente en estivage dans une exploitation agricole suisse",
-		"it": "Tipo e numero di animali da reddito in estivazione in un'azienda agricola svizzera",
-		"en": "Type and number of farm animals summering on a farm in Swiss agriculture"
-	  },
-	  "dct:description": {
-		"de": "Dieses Datenpaket enthält die Art und Anzahl Nutztiere zu einem Betrieb, die im Inland gesömmert wurden. Das Dataset enthält jährlich ab ca. Mitte März die Daten aus dem Vorjahr.",
-		"fr": "Ce paquet de données contient le type et le nombre d'animaux de rente d'une exploitation qui ont été estivés en Suisse. L'ensemble de données contient chaque année, à partir de la mi-mars environ, les données de l'année précédente.",
-		"it": "Questo pacchetto di dati contiene il tipo e il numero di animali da reddito di un'azienda che sono stati estivati in Svizzera. Il set di dati contiene i dati dell'anno precedente a partire da circa metà marzo di ogni anno.",
-		"en": "This data package contains the type and number of farm animals for a holding that have been summered in Switzerland. The dataset contains data from the previous year, available annually from around mid-March."
-	  },
+      "dct:title": {
+        "de": "Art und Anzahl Nutztiere in Sömmerung auf einem Betrieb in der Schweizer Landwirtschaft",
+        "fr": "Type et nombre d'animaux de rente en estivage dans une exploitation agricole suisse",
+        "it": "Tipo e numero di animali da reddito in estivazione in un'azienda agricola svizzera",
+        "en": "Type and number of farm animals summering on a farm in Swiss agriculture"
+      },
+      "dct:description": {
+        "de": "Dieses Datenpaket enthält die Art und Anzahl Nutztiere zu einem Betrieb, die im Inland gesömmert wurden. Das Dataset enthält jährlich ab ca. Mitte März die Daten aus dem Vorjahr.",
+        "fr": "Ce paquet de données contient le type et le nombre d'animaux de rente d'une exploitation qui ont été estivés en Suisse. L'ensemble de données contient chaque année, à partir de la mi-mars environ, les données de l'année précédente.",
+        "it": "Questo pacchetto di dati contiene il tipo e il numero di animali da reddito di un'azienda che sono stati estivati in Svizzera. Il set di dati contiene i dati dell'anno precedente a partire da circa metà marzo di ogni anno.",
+        "en": "This data package contains the type and number of farm animals for a holding that have been summered in Switzerland. The dataset contains data from the previous year, available annually from around mid-March."
+      },
       "adms:status": "published",
       "dct:modified": "2025-03-25",
       "dcat:accessURL": "https://www.blw.admin.ch/de/meine-agrardatenfreigabe",
       "dct:format": "CSV"
     },
-	{
+    {
       "dct:identifier": "32140afd-1b8d-4d72-b522-ff1e50d801f5",
-	  "dct:title": {
-		"de": "Art und Anzahl Nutztiere in Sömmerung auf einem Betrieb in der Schweizer Landwirtschaft - Provisorische Daten",
-		"fr": "Type et nombre d'animaux de rente en estivage dans une exploitation agricole suisse - données provisoires",
-		"it": "Tipo e numero di animali da reddito in estivazione in un'azienda agricola svizzera - dati provvisori",
-		"en": "Type and number of farm animals summering on a farm in Swiss agriculture - provisional data"
-	  },
-	  "dct:description": {
-		"de": "Dieses Datenpaket enthält die Art und Anzahl Nutztiere zu einem Betrieb, die im Inland gesömmert wurden. Das Dataset mit \"provisorischen Daten\" enthält Angaben aus dem laufenden Kalenderjahr.",
-		"fr": "Ce paquet de données contient le type et le nombre d'animaux de rente d'une exploitation qui ont été estivés en Suisse. L'ensemble de données contenant les « données provisoires » contient des informations sur l'année civile en cours.",
-		"it": "Questo pacchetto di dati contiene il tipo e il numero di animali da reddito di un'azienda che sono stati estivati in Svizzera. Il set di dati con \"dati provvisori\" contiene informazioni relative all'anno solare in corso.",
-		"en": "This data package contains the type and number of farm animals for a holding that have been summered in Switzerland. The dataset with \"provisional data\" contains information from the current calendar year."
-	  },
+      "dct:title": {
+        "de": "Art und Anzahl Nutztiere in Sömmerung auf einem Betrieb in der Schweizer Landwirtschaft - Provisorische Daten",
+        "fr": "Type et nombre d'animaux de rente en estivage dans une exploitation agricole suisse - données provisoires",
+        "it": "Tipo e numero di animali da reddito in estivazione in un'azienda agricola svizzera - dati provvisori",
+        "en": "Type and number of farm animals summering on a farm in Swiss agriculture - provisional data"
+      },
+      "dct:description": {
+        "de": "Dieses Datenpaket enthält die Art und Anzahl Nutztiere zu einem Betrieb, die im Inland gesömmert wurden. Das Dataset mit \"provisorischen Daten\" enthält Angaben aus dem laufenden Kalenderjahr.",
+        "fr": "Ce paquet de données contient le type et le nombre d'animaux de rente d'une exploitation qui ont été estivés en Suisse. L'ensemble de données contenant les « données provisoires » contient des informations sur l'année civile en cours.",
+        "it": "Questo pacchetto di dati contiene il tipo e il numero di animali da reddito di un'azienda che sono stati estivati in Svizzera. Il set di dati con \"dati provvisori\" contiene informazioni relative all'anno solare in corso.",
+        "en": "This data package contains the type and number of farm animals for a holding that have been summered in Switzerland. The dataset with \"provisional data\" contains information from the current calendar year."
+      },
       "adms:status": "published",
       "dct:modified": "2025-03-25",
       "dcat:accessURL": "https://www.blw.admin.ch/de/meine-agrardatenfreigabe",
       "dct:format": "CSV"
     }
-  ]
+  ],
+  "bv:externalCatalogs": null
 }

--- a/data/raw/datasets/45d0c17b-80a0-4264-b826-5e68e9c5212d.json
+++ b/data/raw/datasets/45d0c17b-80a0-4264-b826-5e68e9c5212d.json
@@ -13,7 +13,7 @@
     "it": "Prezzo medio annuo di latticini selezionati a livello della catena del valore consumo"
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "marktanalysen@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft, Fachbereich Marktanalysen"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "9a08809b-66f0-4010-993d-43357ccbf514"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "price",
@@ -78,5 +71,11 @@
   "dct:temporal": {
     "dcat:start_date": "2000-01-01",
     "dcat:end_date": "2024-01-01"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "9a08809b-66f0-4010-993d-43357ccbf514"
+    }
+  ]
 }

--- a/data/raw/datasets/4624b7bf-40c4-4249-b25a-98ce06ffa280.json
+++ b/data/raw/datasets/4624b7bf-40c4-4249-b25a-98ce06ffa280.json
@@ -22,7 +22,7 @@
   ],
   "dct:accrualPeriodicity": "AS_NEEDED",
   "dct:modified": "2024-01-01",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "agis@blw.admin.ch",
     "schema:name": "Fachbereich Agrarinformationssysteme"
@@ -42,14 +42,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:typeOfData": "referenceData",
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": false
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "BLW_CD_DZ_PROG",
-    "dcat:accessURL": "https://www.i14y.admin.ch/de/catalog/concepts/08dd50e7-1680-fbf8-afeb-aebe0b019720"
-  },
   "dcat:theme": [
     "agriculture",
     "territory",
@@ -102,5 +94,6 @@
       "dct:format": "CSV",
       "dct:license": "terms_by"
     }
-  ]
+  ],
+  "bv:externalCatalogs": null
 }

--- a/data/raw/datasets/4b56d6fe-2ae6-4084-9ffd-8a2e8116940c.json
+++ b/data/raw/datasets/4b56d6fe-2ae6-4084-9ffd-8a2e8116940c.json
@@ -13,7 +13,7 @@
     "it": "Per tenere opportunamente conto di condizioni di produzione e di vita difficili nell'agricoltura, vengono corrisposti contributi di declività per superfici che danno diritto a pagamenti diretti. Per i pagamenti diretti generali è stato creato un set di dati \"Zone declive\" (OGI 152.1; OPD art. 43) e un secondo set di dati \"Vigneti in zone declive\" (OGI 152.2; OPD art. 45). Sono previste diverse classi di declività. Il set di dati \"Zone declive\" fa parte delle basi di calcolo per i pagamenti diretti agricoli, applicando un sistema d'informazione geografica SIG. I calcoli sono stati effettuati secondo criteri unitari per tutta la Svizzera. La produzione si basa sul modello del terreno \"SwissAlti3D\" di swisstopo. Si distinguono le seguenti classi di declività: <30; 30-50; >50 per cento. Le superfici declive inferiori a un'ara non sono state considerate."
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "info@blw.admin.ch",
     "schema:name": "info@blw.admin.ch"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "8dacb53c-fe50-4cba-98c8-cd45c362d352"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "gradient",
@@ -144,6 +137,12 @@
       },
       "dct:license": "terms_by",
       "schema:comment": "ID for this distribution on opendata.swiss: 103d1237-ffab-49b7-a8f6-883df0aa2975"
+    }
+  ],
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "8dacb53c-fe50-4cba-98c8-cd45c362d352"
     }
   ]
 }

--- a/data/raw/datasets/4edd205d-a51d-44a3-9a6d-dba7e8ced476.json
+++ b/data/raw/datasets/4edd205d-a51d-44a3-9a6d-dba7e8ced476.json
@@ -14,7 +14,7 @@
     "it": "Prezzi mensili dei mangimi al livello del commercio all’ingrosso/trasformazione"
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "marktanalysen@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft, Fachbereich Marktanalysen"
@@ -26,13 +26,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "29e93ad7-f930-4e5a-af46-1c03434fc51e"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "market-data",
@@ -80,5 +73,11 @@
   "dct:temporal": {
     "dcat:start_date": "2013-07-01",
     "dcat:end_date": "2024-12-01"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "29e93ad7-f930-4e5a-af46-1c03434fc51e"
+    }
+  ]
 }

--- a/data/raw/datasets/503810f9-bb0c-47ac-8ca2-aac2c72bfcce.json
+++ b/data/raw/datasets/503810f9-bb0c-47ac-8ca2-aac2c72bfcce.json
@@ -13,7 +13,7 @@
     "it": "I quattro fogli della carta in scala 1:200 000 forniscono una valutazione d'insieme delle condizioni climatiche e delle restrizioni relative all'agricoltura, suddivise in 20 categorie. La carta intende sottolineare le differenze di rilievo relative alle possibilità di coltivazione esistenti nelle singole regioni."
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "info@blw.admin.ch",
     "schema:name": "info@blw.admin.ch"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "04afc289-5142-4678-9498-6f5905fef0b1"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "cultivation-suitability",
@@ -162,6 +155,12 @@
       },
       "dct:license": "terms_by",
       "schema:comment": "ID for this distribution on opendata.swiss: cbb138b0-fa4a-452d-988a-bac0852feb1b"
+    }
+  ],
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "04afc289-5142-4678-9498-6f5905fef0b1"
     }
   ]
 }

--- a/data/raw/datasets/5361e7d7-4ac9-43ab-bdb3-dbec0f030033.json
+++ b/data/raw/datasets/5361e7d7-4ac9-43ab-bdb3-dbec0f030033.json
@@ -22,7 +22,7 @@
   ],
   "dct:accrualPeriodicity": "AS_NEEDED",
   "dct:modified": "2024-01-01",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "agis@blw.admin.ch",
     "schema:name": "Fachbereich Agrarinformationssysteme"
@@ -42,14 +42,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:typeOfData": "referenceData",
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": false
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "BLW_CD_programme_labels",
-    "dcat:accessURL": "https://www.i14y.admin.ch/de/catalog/concepts/08dd3ec4-1417-9745-8b15-d386b0e448f9"
-  },
   "dcat:theme": [
     "agriculture",
     "territory",
@@ -102,5 +94,6 @@
       "dct:format": "CSV",
       "dct:license": "terms_by"
     }
-  ]
+  ],
+  "bv:externalCatalogs": null
 }

--- a/data/raw/datasets/53cc632e-8ef0-490e-aa8d-8c88968f40c8.json
+++ b/data/raw/datasets/53cc632e-8ef0-490e-aa8d-8c88968f40c8.json
@@ -13,7 +13,7 @@
     "it": ""
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "alessandro.rossi@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "47f95729-05ce-4a37-9e63-fefa9bd87f9c"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [],
   "dcat:theme": [
@@ -114,5 +107,11 @@
   "dct:temporal": {
     "dcat:start_date": "2014-01-01",
     "dcat:end_date": "2015-12-31"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "47f95729-05ce-4a37-9e63-fefa9bd87f9c"
+    }
+  ]
 }

--- a/data/raw/datasets/5b685d2e-2b71-468a-b135-a48a98d39e2f.json
+++ b/data/raw/datasets/5b685d2e-2b71-468a-b135-a48a98d39e2f.json
@@ -13,7 +13,7 @@
     "it": ""
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "alessandro.rossi@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "9cbdfde8-508d-4697-84d1-5d21b92c4e9c"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [],
   "dcat:theme": [
@@ -114,5 +107,11 @@
   "dct:temporal": {
     "dcat:start_date": "2004-01-01",
     "dcat:end_date": "2015-12-31"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "9cbdfde8-508d-4697-84d1-5d21b92c4e9c"
+    }
+  ]
 }

--- a/data/raw/datasets/60d72f56-5d43-451a-bdbb-f585ee9b1fd5.json
+++ b/data/raw/datasets/60d72f56-5d43-451a-bdbb-f585ee9b1fd5.json
@@ -13,7 +13,7 @@
     "it": ""
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "alessandro.rossi@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "dcbbfce9-e2e1-4b20-9a5b-b07cc6ecca14"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [],
   "dcat:theme": [
@@ -114,5 +107,11 @@
   "dct:temporal": {
     "dcat:start_date": "1990-01-01",
     "dcat:end_date": "2015-12-31"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "dcbbfce9-e2e1-4b20-9a5b-b07cc6ecca14"
+    }
+  ]
 }

--- a/data/raw/datasets/6b5f4640-d292-4afb-9c8e-626034bdd7fb.json
+++ b/data/raw/datasets/6b5f4640-d292-4afb-9c8e-626034bdd7fb.json
@@ -26,10 +26,7 @@
   "dcatap:availability": "AVAILABLE",
   "bv:classification": "secret",
   "bv:personalData": "sensitivePersonalData",
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
-  "dct:publisher": "BLW ",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:name": "Astat Team",
     "schema:email": "astat@blw.admin.ch"
@@ -52,7 +49,5 @@
   "dct:spatial": "CH",
   "bv:itSystem": "Astat",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": false
-  }
+  "bv:externalCatalogs": null
 }

--- a/data/raw/datasets/6ce7322f-10c4-4a60-8a4b-ea5318b4b8a1.json
+++ b/data/raw/datasets/6ce7322f-10c4-4a60-8a4b-ea5318b4b8a1.json
@@ -14,7 +14,7 @@
   },
   "dct:accessRights": "RESTRICTED",
   "dct:issued": "2020-01-01",
-  "dct:publisher": "BLW-OFAG-UFAG",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:name": "AV MAF, GRKDT",
     "schema:email": "maf@blw.admin.ch"
@@ -25,9 +25,9 @@
     "meine-agrardaten-freigabe",
     "MAF",
     "structural-data",
-	"farm",
-	"animals",
-	"GVE"
+    "farm",
+    "animals",
+    "GVE"
   ],
   "dct:accrualPeriodicity": "ANNUAL",
   "dct:modified": "2025-03-25",
@@ -45,19 +45,13 @@
   "foaf:page": [
     {
       "alias": "PDF: MAF-Verfügbare Datenpakete",
-	  "uri": "https://backend.blw.admin.ch/fileservice/sdweb-docs-prod-blwch-files/files/2024/08/28/3106f5f5-1bcb-4b25-a78a-75c712f2491f.pdf"
+      "uri": "https://backend.blw.admin.ch/fileservice/sdweb-docs-prod-blwch-files/files/2024/08/28/3106f5f5-1bcb-4b25-a78a-75c712f2491f.pdf"
     }
   ],
   "adms:status": "published",
   "bv:classification": "none",
   "bv:personalData": "personalData",
   "bv:typeOfData": "thematicData",
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": false
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "dcat:theme": [
     "agriculture"
   ],
@@ -68,41 +62,42 @@
   "dcat:distribution": [
     {
       "dct:identifier": "2a52517d-20a8-4297-99a7-a4375a992d6f",
-	  "dct:title": {
-		"de": "Art und Anzahl Nutztiere auf einem Betrieb in der Schweizer Landwirtschaft",
-		"fr": "Type et nombre d'animaux de rente dans une exploitation agricole suisse",
-		"it": "Tipo e numero di animali da reddito in un'azienda agricola in Svizzera",
-		"en": "Type and number of farm animals on a farm in Switzerland"
-	  },
-	  "dct:description": {
-		"de": "Dieses Datenpaket enthält die Art und Anzahl Nutztiere, die auf einem Betrieb gehalten werden. Das Dataset enthält jährlich ab ca. Mitte März die Daten aus dem Vorjahr.",
-		"fr": "Ce paquet de données contient le type et le nombre d'animaux de rente détenus dans une exploitation. L'ensemble de données contient chaque année, à partir de la mi-mars environ, les données de l'année précédente.",
-		"it": "Questo pacchetto di dati contiene il tipo e il numero di animali da reddito allevati in un'azienda. Il set di dati contiene i dati dell'anno precedente a partire da circa metà marzo di ogni anno.",
-		"en": "This data package contains the type and number of farm animals kept on a holding. The dataset contains data from the previous year, available annually from around mid-March."
-	  },
+      "dct:title": {
+        "de": "Art und Anzahl Nutztiere auf einem Betrieb in der Schweizer Landwirtschaft",
+        "fr": "Type et nombre d'animaux de rente dans une exploitation agricole suisse",
+        "it": "Tipo e numero di animali da reddito in un'azienda agricola in Svizzera",
+        "en": "Type and number of farm animals on a farm in Switzerland"
+      },
+      "dct:description": {
+        "de": "Dieses Datenpaket enthält die Art und Anzahl Nutztiere, die auf einem Betrieb gehalten werden. Das Dataset enthält jährlich ab ca. Mitte März die Daten aus dem Vorjahr.",
+        "fr": "Ce paquet de données contient le type et le nombre d'animaux de rente détenus dans une exploitation. L'ensemble de données contient chaque année, à partir de la mi-mars environ, les données de l'année précédente.",
+        "it": "Questo pacchetto di dati contiene il tipo e il numero di animali da reddito allevati in un'azienda. Il set di dati contiene i dati dell'anno precedente a partire da circa metà marzo di ogni anno.",
+        "en": "This data package contains the type and number of farm animals kept on a holding. The dataset contains data from the previous year, available annually from around mid-March."
+      },
       "adms:status": "published",
       "dct:modified": "2025-03-25",
       "dcat:accessURL": "https://www.blw.admin.ch/de/meine-agrardatenfreigabe",
       "dct:format": "CSV"
     },
-	{
+    {
       "dct:identifier": "2a33ba7c-0c6c-47f3-b89a-a71380deeee3",
-	  "dct:title": {
-		"de": "Art und Anzahl Nutztiere auf einem Betrieb in der Schweizer Landwirtschaft - Provisorische Daten",
-		"fr": "Type et nombre d'animaux de rente dans une exploitation agricole suisse - données provisoires",
-		"it": "Tipo e numero di animali da reddito in un'azienda agricola in Svizzera - dati provvisori",
-		"en": "Type and number of farm animals on a farm in Switzerland - provisional data"
-	  },
-	  "dct:description": {
-		"de": "Dieses Datenpaket enthält die Art und Anzahl Nutztiere, die auf einem Betrieb gehalten werden. Das Dataset mit \"provisorischen Daten\" enthält Angaben aus dem laufenden Kalenderjahr.",
-		"fr": "Ce paquet de données contient le type et le nombre d'animaux de rente détenus dans une exploitation. L'ensemble de données contenant les « données provisoires » contient des informations sur l'année civile en cours.",
-		"it": "Questo pacchetto di dati contiene il tipo e il numero di animali da reddito allevati in un'azienda. Il set di dati con \"dati provvisori\" contiene informazioni relative all'anno solare in corso.",
-		"en": "This data package contains the type and number of farm animals kept on a holding. The dataset with \"provisional data\" contains information from the current calendar year."
-	  },
+      "dct:title": {
+        "de": "Art und Anzahl Nutztiere auf einem Betrieb in der Schweizer Landwirtschaft - Provisorische Daten",
+        "fr": "Type et nombre d'animaux de rente dans une exploitation agricole suisse - données provisoires",
+        "it": "Tipo e numero di animali da reddito in un'azienda agricola in Svizzera - dati provvisori",
+        "en": "Type and number of farm animals on a farm in Switzerland - provisional data"
+      },
+      "dct:description": {
+        "de": "Dieses Datenpaket enthält die Art und Anzahl Nutztiere, die auf einem Betrieb gehalten werden. Das Dataset mit \"provisorischen Daten\" enthält Angaben aus dem laufenden Kalenderjahr.",
+        "fr": "Ce paquet de données contient le type et le nombre d'animaux de rente détenus dans une exploitation. L'ensemble de données contenant les « données provisoires » contient des informations sur l'année civile en cours.",
+        "it": "Questo pacchetto di dati contiene il tipo e il numero di animali da reddito allevati in un'azienda. Il set di dati con \"dati provvisori\" contiene informazioni relative all'anno solare in corso.",
+        "en": "This data package contains the type and number of farm animals kept on a holding. The dataset with \"provisional data\" contains information from the current calendar year."
+      },
       "adms:status": "published",
       "dct:modified": "2025-03-25",
       "dcat:accessURL": "https://www.blw.admin.ch/de/meine-agrardatenfreigabe",
       "dct:format": "CSV"
     }
-  ]
+  ],
+  "bv:externalCatalogs": null
 }

--- a/data/raw/datasets/6cfb283f-7173-4bfd-8028-f944f153de41.json
+++ b/data/raw/datasets/6cfb283f-7173-4bfd-8028-f944f153de41.json
@@ -29,14 +29,7 @@
   "dcatap:availability": "AVAILABLE",
   "bv:classification": "none",
   "bv:personalData": "none",
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "55f48530-8f03-4058-b26e-387c23c5a48e"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:name": "Bundesamt für Landwirtschaft, Fachbereich Marktanalysen",
     "schema:email": "marktanalysen@blw.admin.ch"
@@ -86,5 +79,11 @@
       "schema:comment": "ID for this distribution on opendata.swiss: 9be4b01d-50ce-4b9b-8f2a-bd55ab3b1e16"
     }
   ],
-  "bv:archivalValue": false
+  "bv:archivalValue": false,
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "55f48530-8f03-4058-b26e-387c23c5a48e"
+    }
+  ]
 }

--- a/data/raw/datasets/6e679770-5782-4e28-9987-f82f3c677ab4.json
+++ b/data/raw/datasets/6e679770-5782-4e28-9987-f82f3c677ab4.json
@@ -13,7 +13,7 @@
     "it": ""
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "alessandro.rossi@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "c9406d6b-a108-42a2-a22b-cf8b03e95d70"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [],
   "dcat:theme": [
@@ -114,5 +107,11 @@
   "dct:temporal": {
     "dcat:start_date": "2015-01-01",
     "dcat:end_date": "2015-12-31"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "c9406d6b-a108-42a2-a22b-cf8b03e95d70"
+    }
+  ]
 }

--- a/data/raw/datasets/6eafa052-a8e3-468c-91cc-5f4880bb0d86.json
+++ b/data/raw/datasets/6eafa052-a8e3-468c-91cc-5f4880bb0d86.json
@@ -14,7 +14,8 @@
     "en": "You can add any description here. Ideally, it should refer to the data record ;)\r\n\r\nchanged i14y-setting to test possible push.\r\nappartently, this is true by default. what will be the publication process?"
   },
   "dcat:theme": [
-    "agriculture"
+    "agriculture",
+    "sct"
   ],
   "dcat:keyword": [
     "edit-test",
@@ -25,9 +26,20 @@
   "dcatap:availability": "EXPERIMENTAL",
   "bv:classification": "none",
   "bv:personalData": "none",
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
+  "prov:qualifiedAttribution": [
+    {
+      "prov:agent": "p-2959456",
+      "schema:name": "NN",
+      "schema:email": "nomen.nescio",
+      "dcat:hadRole": "businessDataOwner"
+    },
+    {
+      "prov:agent": "p-1ZLWBXSJD",
+      "schema:name": "toBeDecided",
+      "schema:email": "t.bd@blw.admin.ch",
+      "dcat:hadRole": "dataSteward"
+    }
+  ],
   "dct:issued": "2025-04-11",
   "dct:modified": "2025-04-11",
   "dct:accrualPeriodicity": "QUARTERLY",
@@ -36,9 +48,49 @@
     "dcat:end_date": ""
   },
   "bv:abrogation": "",
+  "dct:spatial": "CH",
+  "dcat:landingPage": "example.com",
+  "bv:geoIdentifier": "bla",
+  "dcatap:applicableLegislation": [
+    "https://www.fedlex.admin.ch/eli/oc/2022/491/de@art_5",
+    "example.com"
+  ],
+  "prov:wasGeneratedBy": [
+    "link or name of an related business-process"
+  ],
+  "prov:wasDerivedFrom": [
+    "link or id fromwhich this dataset was derivec"
+  ],
+  "bv:itSystem": "IT_SYSTEM_NAME",
   "dcat:version": "0.0.1",
+  "schema:comment": "hello, I am an innocent comment",
+  "dcat:distribution": [
+    {
+      "dct:identifier": "3519e342-8bb1-4aec-b1b9-2b3bc518c384",
+      "dct:title": {
+        "de": "Distribution Title (DE)",
+        "fr": "Distribution Title (FR)",
+        "it": "Distribution Title (IT)",
+        "en": "Distribution Title (EN)"
+      },
+      "dct:description": {
+        "de": "Distribution Description (DE)\r\nLet's try *some* **markup** \\n\\n\\n and obviously line breaks",
+        "fr": "Distribution Description (FR)",
+        "it": "Distribution Description (IT)",
+        "en": "Distribution Description (EN)"
+      },
+      "dcat:accessURL": "linkToDownloadlink.page.com",
+      "adms:status": "workInProgress",
+      "dcatap:availability": "AVAILABLE",
+      "dct:format": "bat",
+      "dct:modified": "0001-10-01",
+      "dcat:downloadURL": "downloadURL_for_ogd.questionmark",
+      "dct:conformsTo": "reference to a standard or specification",
+      "dct:license": "cc-zero",
+      "schema:comment": "distribution_comment"
+    }
+  ],
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": false
-  }
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
+  "bv:externalCatalogs": null
 }

--- a/data/raw/datasets/6ef9cb6b-8af5-409a-a195-93126a224ba7.json
+++ b/data/raw/datasets/6ef9cb6b-8af5-409a-a195-93126a224ba7.json
@@ -13,7 +13,7 @@
     "it": ""
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "alessandro.rossi@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "35f63f53-db5b-4dbd-8655-b1c864bf6c6b"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [],
   "dcat:theme": [
@@ -114,5 +107,11 @@
   "dct:temporal": {
     "dcat:start_date": "1990-01-01",
     "dcat:end_date": "2015-12-31"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "35f63f53-db5b-4dbd-8655-b1c864bf6c6b"
+    }
+  ]
 }

--- a/data/raw/datasets/7050da25-7834-4d96-833a-f4af0d103dd1.json
+++ b/data/raw/datasets/7050da25-7834-4d96-833a-f4af0d103dd1.json
@@ -13,7 +13,7 @@
     "it": "Prezzi medi annui del latte crudo a livello della catena del valore produzione"
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "marktanalysen@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft, Fachbereich Marktanalysen"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "19dd763d-3978-4388-9bab-d3cbc6f535f2"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "market-data",
@@ -78,5 +71,11 @@
   "dct:temporal": {
     "dcat:start_date": "2001-01-01",
     "dcat:end_date": "2024-01-01"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "19dd763d-3978-4388-9bab-d3cbc6f535f2"
+    }
+  ]
 }

--- a/data/raw/datasets/7079407c-c5df-430c-b6bf-75f9216c46b3.json
+++ b/data/raw/datasets/7079407c-c5df-430c-b6bf-75f9216c46b3.json
@@ -14,7 +14,7 @@
   },
   "dct:accessRights": "RESTRICTED",
   "dct:issued": "2020-01-01",
-  "dct:publisher": "BLW-OFAG-UFAG",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:name": "AV MAF, GRKDT",
     "schema:email": "maf@blw.admin.ch"
@@ -25,8 +25,8 @@
     "meine-agrardaten-freigabe",
     "MAF",
     "structural-data",
-	"crops",
-	"connection-areas"
+    "crops",
+    "connection-areas"
   ],
   "dct:accrualPeriodicity": "ANNUAL",
   "dct:modified": "2025-03-25",
@@ -44,19 +44,13 @@
   "foaf:page": [
     {
       "alias": "PDF: MAF-Verfügbare Datenpakete",
-	  "uri": "https://backend.blw.admin.ch/fileservice/sdweb-docs-prod-blwch-files/files/2024/08/28/3106f5f5-1bcb-4b25-a78a-75c712f2491f.pdf"
+      "uri": "https://backend.blw.admin.ch/fileservice/sdweb-docs-prod-blwch-files/files/2024/08/28/3106f5f5-1bcb-4b25-a78a-75c712f2491f.pdf"
     }
   ],
   "adms:status": "published",
   "bv:classification": "none",
   "bv:personalData": "personalData",
   "bv:typeOfData": "thematicData",
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": false
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "dcat:theme": [
     "agriculture"
   ],
@@ -67,41 +61,42 @@
   "dcat:distribution": [
     {
       "dct:identifier": "f384f703-59e1-4f53-b4e1-c6f541dea611",
-	  "dct:title": {
-		"de": "Flächenangaben zu Vernetzungsflächen auf einem Betrieb in der Schweizer Landwirtschaft",
-		"fr": "Indications de superficie pour les surfaces de mise en réseau sur une exploitation agricole suisse",
-		"it": "Dati sulle superfici di interconnessione in un'azienda agricola in Svizzera",
-		"en": "Information on the size of the connection areas on a farm in Swiss agriculture"
-	  },
-	  "dct:description": {
-		"de": "Dieses Datenpaket enthält die Daten zu den Vernetzungsflächen gemäss Direktzahlungsverordnung (DZV). Zu den Flächen wird die Zone, Hauptkultur, Fläche, Ausprägung und Betrieb angegeben. Das Dataset enthält jährlich ab ca. Mitte März die Daten aus dem Vorjahr.",
-		"fr": "Ce paquet de données contient les données relatives aux surfaces de mise en réseau conformément à l'ordonnance sur les paiements directs (OPD). Pour les surfaces, la zone, la culture principale, la surface, la spécification et l'exploitation sont indiquées. L'ensemble de données contient chaque année, à partir de la mi-mars environ, les données de l'année précédente.",
-		"it": "Questo pacchetto di dati contiene i dati relativi alle superfici di interconnessione ai sensi dell'ordinanza sui pagamenti diretti (OPD). Per le superfici vengono indicati la zona, la coltura principale, la superficie, la caratteristica e l'azienda. Il set di dati contiene i dati dell'anno precedente a partire da circa metà marzo di ogni anno.",
-		"en": "This data package contains the data on ecological compensation areas in accordance with the Ordinance on Direct Payments (DZV). The zone, main crop, area, characteristics and holding are indicated for the areas. The dataset contains data from the previous year, available annually from around mid-March."
-	  },
+      "dct:title": {
+        "de": "Flächenangaben zu Vernetzungsflächen auf einem Betrieb in der Schweizer Landwirtschaft",
+        "fr": "Indications de superficie pour les surfaces de mise en réseau sur une exploitation agricole suisse",
+        "it": "Dati sulle superfici di interconnessione in un'azienda agricola in Svizzera",
+        "en": "Information on the size of the connection areas on a farm in Swiss agriculture"
+      },
+      "dct:description": {
+        "de": "Dieses Datenpaket enthält die Daten zu den Vernetzungsflächen gemäss Direktzahlungsverordnung (DZV). Zu den Flächen wird die Zone, Hauptkultur, Fläche, Ausprägung und Betrieb angegeben. Das Dataset enthält jährlich ab ca. Mitte März die Daten aus dem Vorjahr.",
+        "fr": "Ce paquet de données contient les données relatives aux surfaces de mise en réseau conformément à l'ordonnance sur les paiements directs (OPD). Pour les surfaces, la zone, la culture principale, la surface, la spécification et l'exploitation sont indiquées. L'ensemble de données contient chaque année, à partir de la mi-mars environ, les données de l'année précédente.",
+        "it": "Questo pacchetto di dati contiene i dati relativi alle superfici di interconnessione ai sensi dell'ordinanza sui pagamenti diretti (OPD). Per le superfici vengono indicati la zona, la coltura principale, la superficie, la caratteristica e l'azienda. Il set di dati contiene i dati dell'anno precedente a partire da circa metà marzo di ogni anno.",
+        "en": "This data package contains the data on ecological compensation areas in accordance with the Ordinance on Direct Payments (DZV). The zone, main crop, area, characteristics and holding are indicated for the areas. The dataset contains data from the previous year, available annually from around mid-March."
+      },
       "adms:status": "published",
       "dct:modified": "2025-03-25",
       "dcat:accessURL": "https://www.blw.admin.ch/de/meine-agrardatenfreigabe",
       "dct:format": "CSV"
     },
-	{
+    {
       "dct:identifier": "3fe5318f-936e-4601-b2f0-2a0552680b68",
-	  "dct:title": {
-		"de": "Flächenangaben zu Vernetzungsflächen auf einem Betrieb in der Schweizer Landwirtschaft - Provisorische Daten",
-		"fr": "Indications de superficie pour les surfaces de mise en réseau sur une exploitation agricole suisse - données provisoires",
-		"it": "Dati sulle superfici di interconnessione in un'azienda agricola in Svizzera - dati provvisori",
-		"en": "Information on the size of the connection areas on a farm in Swiss agriculture - provisional data"
-	  },
-	  "dct:description": {
-		"de": "Dieses Datenpaket enthält die Daten zu den Vernetzungsflächen gemäss Direktzahlungsverordnung (DZV). Zu den Flächen wird die Zone, Hauptkultur, Fläche, Ausprägung und Betrieb angegeben. Das Dataset mit \"provisorischen Daten\" enthält Angaben aus dem laufenden Kalenderjahr.",
-		"fr": "Ce paquet de données contient les données relatives aux surfaces de mise en réseau conformément à l'ordonnance sur les paiements directs (OPD). Pour les surfaces, la zone, la culture principale, la surface, la spécification et l'exploitation sont indiquées. L'ensemble de données contenant les « données provisoires » contient des informations sur l'année civile en cours.",
-		"it": "Questo pacchetto di dati contiene i dati relativi alle superfici di interconnessione ai sensi dell'ordinanza sui pagamenti diretti (OPD). Per le superfici vengono indicati la zona, la coltura principale, la superficie, la caratteristica e l'azienda. Il set di dati con \"dati provvisori\" contiene informazioni relative all'anno solare in corso.",
-		"en": "This data package contains the data on ecological compensation areas in accordance with the Ordinance on Direct Payments (DZV). The zone, main crop, area, characteristics and holding are indicated for the areas. The dataset with \"provisional data\" contains information from the current calendar year."
-	  },
+      "dct:title": {
+        "de": "Flächenangaben zu Vernetzungsflächen auf einem Betrieb in der Schweizer Landwirtschaft - Provisorische Daten",
+        "fr": "Indications de superficie pour les surfaces de mise en réseau sur une exploitation agricole suisse - données provisoires",
+        "it": "Dati sulle superfici di interconnessione in un'azienda agricola in Svizzera - dati provvisori",
+        "en": "Information on the size of the connection areas on a farm in Swiss agriculture - provisional data"
+      },
+      "dct:description": {
+        "de": "Dieses Datenpaket enthält die Daten zu den Vernetzungsflächen gemäss Direktzahlungsverordnung (DZV). Zu den Flächen wird die Zone, Hauptkultur, Fläche, Ausprägung und Betrieb angegeben. Das Dataset mit \"provisorischen Daten\" enthält Angaben aus dem laufenden Kalenderjahr.",
+        "fr": "Ce paquet de données contient les données relatives aux surfaces de mise en réseau conformément à l'ordonnance sur les paiements directs (OPD). Pour les surfaces, la zone, la culture principale, la surface, la spécification et l'exploitation sont indiquées. L'ensemble de données contenant les « données provisoires » contient des informations sur l'année civile en cours.",
+        "it": "Questo pacchetto di dati contiene i dati relativi alle superfici di interconnessione ai sensi dell'ordinanza sui pagamenti diretti (OPD). Per le superfici vengono indicati la zona, la coltura principale, la superficie, la caratteristica e l'azienda. Il set di dati con \"dati provvisori\" contiene informazioni relative all'anno solare in corso.",
+        "en": "This data package contains the data on ecological compensation areas in accordance with the Ordinance on Direct Payments (DZV). The zone, main crop, area, characteristics and holding are indicated for the areas. The dataset with \"provisional data\" contains information from the current calendar year."
+      },
       "adms:status": "published",
       "dct:modified": "2025-03-25",
       "dcat:accessURL": "https://www.blw.admin.ch/de/meine-agrardatenfreigabe",
       "dct:format": "CSV"
     }
-  ]
+  ],
+  "bv:externalCatalogs": null
 }

--- a/data/raw/datasets/721bd8d0-1c8e-411b-bf56-4b434f8d7a91.json
+++ b/data/raw/datasets/721bd8d0-1c8e-411b-bf56-4b434f8d7a91.json
@@ -13,7 +13,7 @@
     "it": ""
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "alessandro.rossi@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "234d2568-4fb1-4624-872b-ee5e35c83955"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [],
   "dcat:theme": [
@@ -114,5 +107,11 @@
   "dct:temporal": {
     "dcat:start_date": "2000-01-01",
     "dcat:end_date": "2015-12-31"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "234d2568-4fb1-4624-872b-ee5e35c83955"
+    }
+  ]
 }

--- a/data/raw/datasets/72c29f4d-206e-4fb7-9286-33b077cc0411.json
+++ b/data/raw/datasets/72c29f4d-206e-4fb7-9286-33b077cc0411.json
@@ -13,7 +13,7 @@
     "it": "Prezzo medio mensile di latticini selezionati a livello della catena del valore consumo"
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "marktanalysen@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft, Fachbereich Marktanalysen"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "5119fedb-89ec-448c-89a3-274bea5acd62"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "price",
@@ -78,5 +71,11 @@
   "dct:temporal": {
     "dcat:start_date": "2000-01-01",
     "dcat:end_date": "2025-01-01"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "5119fedb-89ec-448c-89a3-274bea5acd62"
+    }
+  ]
 }

--- a/data/raw/datasets/738bfce1-5732-46f7-b529-e82dacaa6352.json
+++ b/data/raw/datasets/738bfce1-5732-46f7-b529-e82dacaa6352.json
@@ -14,7 +14,7 @@
     "it": "Prezzi annui per cereali panificabili, farina e prodotti da forno al livello del commercio all’ingrosso/trasformazione"
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "marktanalysen@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft, Fachbereich Marktanalysen"
@@ -26,13 +26,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "4a778f45-2b65-4883-a1aa-6573de189c39"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "market-data",
@@ -79,5 +72,11 @@
   "dct:temporal": {
     "dcat:start_date": "2016-01-01",
     "dcat:end_date": "2024-01-01"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "4a778f45-2b65-4883-a1aa-6573de189c39"
+    }
+  ]
 }

--- a/data/raw/datasets/7787558f-6d0e-4b11-b015-cb128ff53523.json
+++ b/data/raw/datasets/7787558f-6d0e-4b11-b015-cb128ff53523.json
@@ -13,7 +13,7 @@
     "it": "Volumi mensili di latte crudo commercializzato a livello della catena del valore produzione"
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "marktanalysen@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft, Fachbereich Marktanalysen"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "dc3c96bd-6ec9-4ecd-b798-e78c62d24e25"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "market-data",
@@ -78,5 +71,11 @@
   "dct:temporal": {
     "dcat:start_date": "2001-01-01",
     "dcat:end_date": "2024-12-01"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "dc3c96bd-6ec9-4ecd-b798-e78c62d24e25"
+    }
+  ]
 }

--- a/data/raw/datasets/82fcca67-633d-431d-853d-1bf765a70bc6.json
+++ b/data/raw/datasets/82fcca67-633d-431d-853d-1bf765a70bc6.json
@@ -28,7 +28,7 @@
     "c61f6636-f09f-433e-8612-4babd5a3a9f4",
     "a88a2dfa-f5fb-4fe2-a1c5-af392052f6a2"
   ],
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "bv:archivalValue": false,
   "prov:qualifiedAttribution": [
     {
@@ -44,14 +44,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:typeOfData": "referenceData",
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": false
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "BLW_CD_PFC_DueV",
-    "dcat:accessURL": "https://www.i14y.admin.ch/de/catalog/concepts/08dc7ef4-e871-d36f-ade1-d11f8e073447"
-  },
   "dcat:theme": [
     "agriculture",
     "territory"
@@ -102,5 +94,6 @@
       "dct:format": "CSV",
       "dct:license": "terms_by"
     }
-  ]
+  ],
+  "bv:externalCatalogs": null
 }

--- a/data/raw/datasets/833cdbbb-9e6a-47fb-8626-d03b80c7468d.json
+++ b/data/raw/datasets/833cdbbb-9e6a-47fb-8626-d03b80c7468d.json
@@ -13,7 +13,7 @@
     "it": "I blocchi di particelle sono superfici contigue utilizzabili a scopo agricolo circondate da confini relativamente stabili e visibili sul campo (p.es. foresta, strade, superfici edificate, corsi d’acqua, fossati). Il modello topografico del paesaggio (MTP3D) costituisce la base di calcolo. Un blocco di particelle rappresenta pertanto un comprensorio idrologico chiuso, in cui tutti i pixel possono essere collegati dal profilo idrologico e di conseguenza influenzarsi a vicenda per quanto riguarda l’erosione. Nel modello, altri blocchi di particelle o superfici al di fuori di un blocco di particelle non possono influenzare i flussi d’acqua e l’erosione all’interno di un blocco di particelle. Secondo il modello, quindi, non può esserci afflusso di acque estranee. La dimensione minima di un blocco di particelle è stata fissata a 25 are. Il monitoraggio dell’erosione sulle superfici coltive da parte delle autorità competenti avviene preferibilmente verificando i blocchi di particelle nelle zone agricole prioritarie. È necessario rivedere il calcolo del rischio di erosione in caso di variazione della dimensione del blocco di particelle, per esempio in seguito alla costruzione di nuove strade oppure all’impianto o alla rimozione di siepi."
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "info@blw.admin.ch",
     "schema:name": "info@blw.admin.ch"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "79a82202-4743-4f99-92a6-eb42b365b19f"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "soil",
@@ -139,6 +132,12 @@
       },
       "dct:license": "terms_by",
       "schema:comment": "ID for this distribution on opendata.swiss: b7a2ed9c-77d6-4e15-93dd-a38cb3a4d8cc"
+    }
+  ],
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "79a82202-4743-4f99-92a6-eb42b365b19f"
     }
   ]
 }

--- a/data/raw/datasets/83f93ff4-ef3f-43f1-af2c-83f18952283e.json
+++ b/data/raw/datasets/83f93ff4-ef3f-43f1-af2c-83f18952283e.json
@@ -31,10 +31,7 @@
   "dcatap:availability": "AVAILABLE",
   "bv:classification": "none",
   "bv:personalData": "none",
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true
-  },
-  "dct:publisher": "Federal Office for Agriculture",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:name": "DigiAgriFoodCH",
     "schema:email": "info@digiagrifood.ch"
@@ -122,7 +119,10 @@
     }
   ],
   "bv:archivalValue": false,
-  "bv:i14y": {
-    "bv:mustBePublished": false
-  }
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": ""
+    }
+  ]
 }

--- a/data/raw/datasets/8432bc6e-262f-40dd-b380-2bc39f9efa32.json
+++ b/data/raw/datasets/8432bc6e-262f-40dd-b380-2bc39f9efa32.json
@@ -14,7 +14,7 @@
   },
   "dct:accessRights": "RESTRICTED",
   "dct:issued": "2020-01-01",
-  "dct:publisher": "BLW-OFAG-UFAG",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:name": "AV MAF, GRKDT",
     "schema:email": "maf@blw.admin.ch"
@@ -25,8 +25,8 @@
     "meine-agrardaten-freigabe",
     "MAF",
     "structural-data",
-	"crops",
-	"slope-gradient"
+    "crops",
+    "slope-gradient"
   ],
   "dct:accrualPeriodicity": "ANNUAL",
   "dct:modified": "2025-03-25",
@@ -44,19 +44,13 @@
   "foaf:page": [
     {
       "alias": "PDF: MAF-Verfügbare Datenpakete",
-	  "uri": "https://backend.blw.admin.ch/fileservice/sdweb-docs-prod-blwch-files/files/2024/08/28/3106f5f5-1bcb-4b25-a78a-75c712f2491f.pdf"
+      "uri": "https://backend.blw.admin.ch/fileservice/sdweb-docs-prod-blwch-files/files/2024/08/28/3106f5f5-1bcb-4b25-a78a-75c712f2491f.pdf"
     }
   ],
   "adms:status": "published",
   "bv:classification": "none",
   "bv:personalData": "personalData",
   "bv:typeOfData": "thematicData",
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": false
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "dcat:theme": [
     "agriculture"
   ],
@@ -67,41 +61,42 @@
   "dcat:distribution": [
     {
       "dct:identifier": "0061d4af-8af9-4f62-906f-f9350d86a8b6",
-	  "dct:title": {
-		"de": "Flächenangaben zu Fächen in Hanglagen auf einem Betrieb in der Schweizer Landwirtschaft",
-		"fr": "Indications de surface pour les surfaces en pente d'une exploitation agricole suisse",
-		"it": "Dati relativi alle superfici in pendenza in un'azienda agricola svizzera",
-		"en": "Information on the area of sloping fields on a farm in Swiss agriculture"
-	  },
-	  "dct:description": {
-		"de": "Dieses Datenpaket enthält Flächen, die in einem Hang liegen mit einer Neigung grösser als 18%. Zu den Flächen wird die Hauptkultur, Hangneigung, Zone und Betrieb angegeben. Das Dataset enthält jährlich ab ca. Mitte März die Daten aus dem Vorjahr.",
-		"fr": "Ce paquet de données contient des surfaces situées sur une pente dont l'inclinaison est supérieure à 18 %. La culture principale, l'inclinaison de la pente, la zone et l'exploitation sont indiquées pour les surfaces. L'ensemble de données contient chaque année, à partir de la mi-mars environ, les données de l'année précédente.",
-		"it": "Questo pacchetto di dati contiene superfici situate su un pendio con una pendenza superiore al 18%. Per le superfici vengono indicati la coltura principale, la pendenza del pendio, la zona e l'azienda. Il set di dati contiene i dati dell'anno precedente a partire da circa metà marzo di ogni anno.",
-		"en": "This data package contains areas that are located on slopes with an inclination of more than 18%. The main crop, slope inclination, zone and farm are indicated for the areas. The dataset contains data from the previous year, available annually from around mid-March."
-	  },
+      "dct:title": {
+        "de": "Flächenangaben zu Fächen in Hanglagen auf einem Betrieb in der Schweizer Landwirtschaft",
+        "fr": "Indications de surface pour les surfaces en pente d'une exploitation agricole suisse",
+        "it": "Dati relativi alle superfici in pendenza in un'azienda agricola svizzera",
+        "en": "Information on the area of sloping fields on a farm in Swiss agriculture"
+      },
+      "dct:description": {
+        "de": "Dieses Datenpaket enthält Flächen, die in einem Hang liegen mit einer Neigung grösser als 18%. Zu den Flächen wird die Hauptkultur, Hangneigung, Zone und Betrieb angegeben. Das Dataset enthält jährlich ab ca. Mitte März die Daten aus dem Vorjahr.",
+        "fr": "Ce paquet de données contient des surfaces situées sur une pente dont l'inclinaison est supérieure à 18 %. La culture principale, l'inclinaison de la pente, la zone et l'exploitation sont indiquées pour les surfaces. L'ensemble de données contient chaque année, à partir de la mi-mars environ, les données de l'année précédente.",
+        "it": "Questo pacchetto di dati contiene superfici situate su un pendio con una pendenza superiore al 18%. Per le superfici vengono indicati la coltura principale, la pendenza del pendio, la zona e l'azienda. Il set di dati contiene i dati dell'anno precedente a partire da circa metà marzo di ogni anno.",
+        "en": "This data package contains areas that are located on slopes with an inclination of more than 18%. The main crop, slope inclination, zone and farm are indicated for the areas. The dataset contains data from the previous year, available annually from around mid-March."
+      },
       "adms:status": "published",
       "dct:modified": "2025-03-25",
       "dcat:accessURL": "https://www.blw.admin.ch/de/meine-agrardatenfreigabe",
       "dct:format": "CSV"
     },
-	{
+    {
       "dct:identifier": "92b984cd-72b9-464c-aa48-5b36e5d2a349",
-	  "dct:title": {
-		"de": "Flächenangaben zu Fächen in Hanglagen auf einem Betrieb in der Schweizer Landwirtschaft - Provisorische Daten",
-		"fr": "Indications de surface pour les surfaces en pente d'une exploitation agricole suisse - données provisoires",
-		"it": "Dati relativi alle superfici in pendenza in un'azienda agricola svizzera - dati provvisori",
-		"en": "Information on the area of sloping fields on a farm in Swiss agriculture - provisional data"
-	  },
-	  "dct:description": {
-		"de": "Dieses Datenpaket enthält Flächen, die in einem Hang liegen mit einer Neigung grösser als 18%. Zu den Flächen wird die Hauptkultur, Hangneigung, Zone und Betrieb angegeben. Das Dataset mit \"provisorischen Daten\" enthält Angaben aus dem laufenden Kalenderjahr.",
-		"fr": "Ce paquet de données contient des surfaces situées sur une pente dont l'inclinaison est supérieure à 18 %. La culture principale, l'inclinaison de la pente, la zone et l'exploitation sont indiquées pour les surfaces. L'ensemble de données contenant les « données provisoires » contient des informations sur l'année civile en cours.",
-		"it": "Questo pacchetto di dati contiene superfici situate su un pendio con una pendenza superiore al 18%. Per le superfici vengono indicati la coltura principale, la pendenza del pendio, la zona e l'azienda. Il set di dati con \"dati provvisori\" contiene informazioni relative all'anno solare in corso.",
-		"en": "This data package contains areas that are located on slopes with an inclination of more than 18%. The main crop, slope inclination, zone and farm are indicated for the areas. The dataset with \"provisional data\" contains information from the current calendar year."
-	  },
+      "dct:title": {
+        "de": "Flächenangaben zu Fächen in Hanglagen auf einem Betrieb in der Schweizer Landwirtschaft - Provisorische Daten",
+        "fr": "Indications de surface pour les surfaces en pente d'une exploitation agricole suisse - données provisoires",
+        "it": "Dati relativi alle superfici in pendenza in un'azienda agricola svizzera - dati provvisori",
+        "en": "Information on the area of sloping fields on a farm in Swiss agriculture - provisional data"
+      },
+      "dct:description": {
+        "de": "Dieses Datenpaket enthält Flächen, die in einem Hang liegen mit einer Neigung grösser als 18%. Zu den Flächen wird die Hauptkultur, Hangneigung, Zone und Betrieb angegeben. Das Dataset mit \"provisorischen Daten\" enthält Angaben aus dem laufenden Kalenderjahr.",
+        "fr": "Ce paquet de données contient des surfaces situées sur une pente dont l'inclinaison est supérieure à 18 %. La culture principale, l'inclinaison de la pente, la zone et l'exploitation sont indiquées pour les surfaces. L'ensemble de données contenant les « données provisoires » contient des informations sur l'année civile en cours.",
+        "it": "Questo pacchetto di dati contiene superfici situate su un pendio con una pendenza superiore al 18%. Per le superfici vengono indicati la coltura principale, la pendenza del pendio, la zona e l'azienda. Il set di dati con \"dati provvisori\" contiene informazioni relative all'anno solare in corso.",
+        "en": "This data package contains areas that are located on slopes with an inclination of more than 18%. The main crop, slope inclination, zone and farm are indicated for the areas. The dataset with \"provisional data\" contains information from the current calendar year."
+      },
       "adms:status": "published",
       "dct:modified": "2025-03-25",
       "dcat:accessURL": "https://www.blw.admin.ch/de/meine-agrardatenfreigabe",
       "dct:format": "CSV"
     }
-  ]
+  ],
+  "bv:externalCatalogs": null
 }

--- a/data/raw/datasets/884d2c24-6d25-4d73-9ad9-18a85b83c4b9.json
+++ b/data/raw/datasets/884d2c24-6d25-4d73-9ad9-18a85b83c4b9.json
@@ -13,7 +13,7 @@
     "it": ""
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "alessandro.rossi@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "a439114f-7fda-4a22-a486-bee05ec03984"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [],
   "dcat:theme": [
@@ -114,5 +107,11 @@
   "dct:temporal": {
     "dcat:start_date": "2014-01-01",
     "dcat:end_date": "2015-12-31"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "a439114f-7fda-4a22-a486-bee05ec03984"
+    }
+  ]
 }

--- a/data/raw/datasets/8884a856-8647-4943-b511-1636f27f7604.json
+++ b/data/raw/datasets/8884a856-8647-4943-b511-1636f27f7604.json
@@ -13,7 +13,7 @@
     "it": "Il Registro delle denominazioni di origine (DOP) e delle indicazioni geografiche (IGP) consente di tutelare i nomi geografici e tradizionali che designano prodotti agricoli (ad eccezione del vino) la cui qualità e le cui caratteristiche principali sono determinate dalla loro origine. L'utilizzo di un nome protetto è appannaggio dei produttori della zona geografica definita che ottemperano ad un dettagliato elenco degli obblighi. La protezione di determinate denominazioni di prodotti agricoli è finalizzata a tutelare i consumatori dalle frodi e a proteggere i contadini dalla concorrenza sleale dovuta all'abuso delle denominazioni. La regolamentazione applicabile in questo settore permette il reciproco riconoscimento dei prodotti di qualità tra Svizzera e UE. Le DOP/IGP sono suddivise in quattro categorie: formaggi, prodotti carnei, prodotti vegetali e distillati. Attualmente il registro delle DOP/IGP conta 30 prodotti e il numero di registrazioni è in costante aumento."
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "info@blw.admin.ch",
     "schema:name": "info@blw.admin.ch"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "55d1451b-9d9a-4e88-921d-b901f5b2de17"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "protected-geographical-indication",
@@ -166,6 +159,12 @@
       },
       "dct:license": "terms_by",
       "schema:comment": "ID for this distribution on opendata.swiss: 35f8a5a7-20e2-4898-bba0-bfac90f3147d"
+    }
+  ],
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "55d1451b-9d9a-4e88-921d-b901f5b2de17"
     }
   ]
 }

--- a/data/raw/datasets/891e97ca-316c-43eb-9b0c-c0652bfd3f76.json
+++ b/data/raw/datasets/891e97ca-316c-43eb-9b0c-c0652bfd3f76.json
@@ -13,7 +13,7 @@
     "it": ""
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "alessandro.rossi@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "30981f07-dc91-4df5-9001-f008223a5524"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [],
   "dcat:theme": [
@@ -114,5 +107,11 @@
   "dct:temporal": {
     "dcat:start_date": "1999-01-01",
     "dcat:end_date": "2015-12-31"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "30981f07-dc91-4df5-9001-f008223a5524"
+    }
+  ]
 }

--- a/data/raw/datasets/8a4208a2-b235-47fd-922b-79ddc9d53f8a.json
+++ b/data/raw/datasets/8a4208a2-b235-47fd-922b-79ddc9d53f8a.json
@@ -13,7 +13,7 @@
     "it": "Prezzi medi annui delle uova nella fase di produzione della catena dei valore"
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "marktanalysen@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft, Fachbereich Marktanalysen"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "8a7ba17b-6cd6-47ae-bb93-441b03b9dcde"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "market-data",
@@ -78,5 +71,11 @@
   "dct:temporal": {
     "dcat:start_date": "2001-01-01",
     "dcat:end_date": "2024-01-01"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "8a7ba17b-6cd6-47ae-bb93-441b03b9dcde"
+    }
+  ]
 }

--- a/data/raw/datasets/8a9bd3f6-9e36-4ae1-80c0-9e3377877a6f.json
+++ b/data/raw/datasets/8a9bd3f6-9e36-4ae1-80c0-9e3377877a6f.json
@@ -14,7 +14,7 @@
     "it": "Prezzi medi mensili delle oleaginose al livello del consumo"
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "marktanalysen@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft, Fachbereich Marktanalysen"
@@ -26,13 +26,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "889b2128-a9f9-449e-9218-3c289bbd8faa"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "market-data",
@@ -80,5 +73,11 @@
   "dct:temporal": {
     "dcat:start_date": "2020-01-01",
     "dcat:end_date": "2024-10-01"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "889b2128-a9f9-449e-9218-3c289bbd8faa"
+    }
+  ]
 }

--- a/data/raw/datasets/8c6da8f4-bfb6-41dc-bd94-1447fb3d5f83.json
+++ b/data/raw/datasets/8c6da8f4-bfb6-41dc-bd94-1447fb3d5f83.json
@@ -14,7 +14,7 @@
     "it": "Prezzi annui dei mangimi al livello del commercio all’ingrosso/trasformazione"
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "marktanalysen@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft, Fachbereich Marktanalysen"
@@ -26,13 +26,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "b5be6ebc-5b78-42e9-949a-a83c7c9960f4"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "market-data",
@@ -80,5 +73,11 @@
   "dct:temporal": {
     "dcat:start_date": "2013-01-01",
     "dcat:end_date": "2024-01-01"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "b5be6ebc-5b78-42e9-949a-a83c7c9960f4"
+    }
+  ]
 }

--- a/data/raw/datasets/8c8fffb8-c9a0-43cc-83c7-e046b76d82b2.json
+++ b/data/raw/datasets/8c8fffb8-c9a0-43cc-83c7-e046b76d82b2.json
@@ -13,7 +13,7 @@
     "it": ""
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "alessandro.rossi@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "9d72dd2a-0d32-464f-ad2b-4ad82af111d6"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [],
   "dcat:theme": [
@@ -114,5 +107,11 @@
   "dct:temporal": {
     "dcat:start_date": "1999-01-01",
     "dcat:end_date": "2015-12-31"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "9d72dd2a-0d32-464f-ad2b-4ad82af111d6"
+    }
+  ]
 }

--- a/data/raw/datasets/8fd9f464-5421-4dba-82f7-06105d9dbeaa.json
+++ b/data/raw/datasets/8fd9f464-5421-4dba-82f7-06105d9dbeaa.json
@@ -13,7 +13,7 @@
     "it": "La designazione “alpe” (p.es. formaggio d'alpe) può essere impiegata se le materie prime provengono dalla regione d'estivazione e se lì sono trasformate.La trasformazione dei seguenti prodotti può avvenire anche al di fuori della regione d'estivazione: latte pronto al consumo, panna pronta al consumo, maturazione del formaggio, nonché macellazione e sezionamento degli animali. La designazione «alpe» può essere utilizzata anche nella caratterizzazione di una derrata alimentare composta da più ingredienti anche se la derrata alimentare in sé non adempie le esigenze per l'impiego della designazione «alpe». La designazione «alpe» può riferirsi esclusivamente agli ingredienti in questione (p.es. «yogurt con latte dell'alpe») (RS 910.19)."
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "info@blw.admin.ch",
     "schema:name": "info@blw.admin.ch"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "3d44c5fb-eb7f-4c9e-9422-88868f7fe60c"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "alpine-economy",
@@ -143,6 +136,12 @@
       },
       "dct:license": "terms_by",
       "schema:comment": "ID for this distribution on opendata.swiss: b11116ce-f6b1-48fc-971a-73b36c0286c5"
+    }
+  ],
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "3d44c5fb-eb7f-4c9e-9422-88868f7fe60c"
     }
   ]
 }

--- a/data/raw/datasets/9148d59a-a270-4719-a2ec-9d67d2d850f1.json
+++ b/data/raw/datasets/9148d59a-a270-4719-a2ec-9d67d2d850f1.json
@@ -13,7 +13,7 @@
     "it": "A complemento della carta delle superfici collegate ad acque superficiali, ne è stata allestita una che consente di distinguere tra collegamento diretto e indiretto alle acque superficiali. Le superfici collegate direttamente ad acque superficiali sono ubicate in prossimità di corsi d'acqua oppure collegate ad essi mediante fossati temporaneamente portatori d'acqua o linee di profondità. Mediante pozzetti di drenaggio e pozzetti d'entrata dell'evacuazione delle acque delle strade, il deflusso superficiale può giungere nel corso d'acqua anche indirettamente. Grazie a quest'informazione è possibile pianificare in maniera ancora più mirata i provvedimenti contro l'immissione di sostanze nei corsi d'acqua. I probabili collegamenti delle superfici agricole ai corsi d'acqua si suddividono in sei categorie."
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "info@blw.admin.ch",
     "schema:name": "info@blw.admin.ch"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "4e49f596-d0b6-4473-9c77-7cf4f1008969"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "conservation",
@@ -142,6 +135,12 @@
       },
       "dct:license": "terms_by",
       "schema:comment": "ID for this distribution on opendata.swiss: 25c1798a-d1b8-461e-af02-dd908823ddc1"
+    }
+  ],
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "4e49f596-d0b6-4473-9c77-7cf4f1008969"
     }
   ]
 }

--- a/data/raw/datasets/92dd7020-b18b-4bd8-9159-31ceb588747d.json
+++ b/data/raw/datasets/92dd7020-b18b-4bd8-9159-31ceb588747d.json
@@ -13,7 +13,7 @@
     "it": ""
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "alessandro.rossi@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "3fc01587-2de5-4fc8-a1dd-8c6f4aaefd4e"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [],
   "dcat:theme": [
@@ -114,5 +107,11 @@
   "dct:temporal": {
     "dcat:start_date": "1990-01-01",
     "dcat:end_date": "2015-12-31"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "3fc01587-2de5-4fc8-a1dd-8c6f4aaefd4e"
+    }
+  ]
 }

--- a/data/raw/datasets/93362440-dafa-42ef-aa6c-b05928eec867.json
+++ b/data/raw/datasets/93362440-dafa-42ef-aa6c-b05928eec867.json
@@ -13,7 +13,7 @@
     "it": "Prezzi medi annui delle uova importate e di una selezione di prodotti importati a base di uovai a livello della catena del valore transformazione e consumi"
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "marktanalysen@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft, Fachbereich Marktanalysen"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "7f74b325-02a2-40de-9b2d-81f1ded24764"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "price",
@@ -78,5 +71,11 @@
   "dct:temporal": {
     "dcat:start_date": "2017-01-01",
     "dcat:end_date": "2024-01-01"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "7f74b325-02a2-40de-9b2d-81f1ded24764"
+    }
+  ]
 }

--- a/data/raw/datasets/9416a47b-b7e2-4fca-ad5f-1f64fb230362.json
+++ b/data/raw/datasets/9416a47b-b7e2-4fca-ad5f-1f64fb230362.json
@@ -13,7 +13,7 @@
     "it": "Il Registro delle denominazioni di origine (DOP) e delle indicazioni geografiche (IGP) consente di tutelare i nomi geografici e tradizionali che designano prodotti agricoli (ad eccezione del vino) la cui qualità e le cui caratteristiche principali sono determinate dalla loro origine. L'utilizzo di un nome protetto è appannaggio dei produttori della zona geografica definita che ottemperano ad un dettagliato elenco degli obblighi. La protezione di determinate denominazioni di prodotti agricoli è finalizzata a tutelare i consumatori dalle frodi e a proteggere i contadini dalla concorrenza sleale dovuta all'abuso delle denominazioni. La regolamentazione applicabile in questo settore permette il reciproco riconoscimento dei prodotti di qualità tra Svizzera e UE. Le DOP/IGP sono suddivise in quattro categorie: formaggi, prodotti carnei, prodotti vegetali e distillati. Attualmente il registro delle DOP/IGP conta 30 prodotti e il numero di registrazioni è in costante aumento."
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "info@blw.admin.ch",
     "schema:name": "info@blw.admin.ch"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "c11df334-e906-44b8-8fab-22fed980958c"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "protected-designation-of-origin",
@@ -167,6 +160,12 @@
       },
       "dct:license": "terms_by",
       "schema:comment": "ID for this distribution on opendata.swiss: 648eed79-5257-4203-9c1f-bd1e7f95f04a"
+    }
+  ],
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "c11df334-e906-44b8-8fab-22fed980958c"
     }
   ]
 }

--- a/data/raw/datasets/95952e08-f90f-4e9c-8228-fb1e9d99ef87.json
+++ b/data/raw/datasets/95952e08-f90f-4e9c-8228-fb1e9d99ef87.json
@@ -13,7 +13,7 @@
     "it": ""
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "alessandro.rossi@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "48415b81-f623-469a-8473-c62964f53fbb"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [],
   "dcat:theme": [
@@ -114,5 +107,11 @@
   "dct:temporal": {
     "dcat:start_date": "1999-01-01",
     "dcat:end_date": "2015-12-31"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "48415b81-f623-469a-8473-c62964f53fbb"
+    }
+  ]
 }

--- a/data/raw/datasets/96b1ba2f-e8d8-4b9e-a35c-5a90e0f389be.json
+++ b/data/raw/datasets/96b1ba2f-e8d8-4b9e-a35c-5a90e0f389be.json
@@ -13,7 +13,7 @@
     "it": "Indice dei prezzi annuo sul mercato lattiero"
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "marktanalysen@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft, Fachbereich Marktanalysen"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "11fce6a7-6f94-4500-85dd-5b33eda6d9dc"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "price",
@@ -78,5 +71,11 @@
   "dct:temporal": {
     "dcat:start_date": "2010-01-01",
     "dcat:end_date": "2024-01-01"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "11fce6a7-6f94-4500-85dd-5b33eda6d9dc"
+    }
+  ]
 }

--- a/data/raw/datasets/9a7053d8-6470-4f8b-9c56-e264f02789e9.json
+++ b/data/raw/datasets/9a7053d8-6470-4f8b-9c56-e264f02789e9.json
@@ -13,7 +13,7 @@
     "it": "Volumi annuali di uova importate e di una selezione di prodotti importati a base di uova a livello della catena di valore transformazione e consumi"
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "marktanalysen@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft, Fachbereich Marktanalysen"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "0c391726-45f9-4f26-b9fd-c567e954659e"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "market-data",
@@ -78,5 +71,11 @@
   "dct:temporal": {
     "dcat:start_date": "2001-01-01",
     "dcat:end_date": "2024-01-01"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "0c391726-45f9-4f26-b9fd-c567e954659e"
+    }
+  ]
 }

--- a/data/raw/datasets/9b44e4dd-0e82-4c0f-8bea-cf3a57013733.json
+++ b/data/raw/datasets/9b44e4dd-0e82-4c0f-8bea-cf3a57013733.json
@@ -13,7 +13,7 @@
     "it": ""
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "alessandro.rossi@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "767d09e4-d0f4-4dcf-9816-91e37bfa797d"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [],
   "dcat:theme": [
@@ -112,5 +105,11 @@
   "dct:temporal": {
     "dcat:start_date": "1999-01-01",
     "dcat:end_date": "2015-12-31"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "767d09e4-d0f4-4dcf-9816-91e37bfa797d"
+    }
+  ]
 }

--- a/data/raw/datasets/9db57343-7891-4072-b5b8-b786c7c197ad.json
+++ b/data/raw/datasets/9db57343-7891-4072-b5b8-b786c7c197ad.json
@@ -13,7 +13,7 @@
     "it": "Prezzi medi mensili delle uova importate e di una selezione di prodotti importati a base di uova a livello della catena del valore transformazione e consumi"
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "marktanalysen@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft, Fachbereich Marktanalysen"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "9f78a795-0a94-4a97-91f2-813933bfbb07"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "price",
@@ -78,5 +71,11 @@
   "dct:temporal": {
     "dcat:start_date": "2017-01-01",
     "dcat:end_date": "2024-12-01"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "9f78a795-0a94-4a97-91f2-813933bfbb07"
+    }
+  ]
 }

--- a/data/raw/datasets/9fccd3a6-fbaf-41cc-9ade-7c53d8c9cc8e.json
+++ b/data/raw/datasets/9fccd3a6-fbaf-41cc-9ade-7c53d8c9cc8e.json
@@ -13,7 +13,7 @@
     "it": "Prezzi medi mensili del latte crudo a livello della catena del valore produzione"
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "marktanalysen@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft, Fachbereich Marktanalysen"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "8e494087-0931-4f2c-932b-67913ed57bf1"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "market-data",
@@ -78,5 +71,11 @@
   "dct:temporal": {
     "dcat:start_date": "2001-01-01",
     "dcat:end_date": "2025-01-01"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "8e494087-0931-4f2c-932b-67913ed57bf1"
+    }
+  ]
 }

--- a/data/raw/datasets/a39a06f5-f356-4510-98a3-eceed56b5cad.json
+++ b/data/raw/datasets/a39a06f5-f356-4510-98a3-eceed56b5cad.json
@@ -13,7 +13,7 @@
     "it": "Indice di prezzo mensile sul mercato lattiero"
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "marktanalysen@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft, Fachbereich Marktanalysen"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "6b0a2fac-5a53-4320-bc1d-d39546ca4f44"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "price",
@@ -78,5 +71,11 @@
   "dct:temporal": {
     "dcat:start_date": "2010-01-01",
     "dcat:end_date": "2024-12-01"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "6b0a2fac-5a53-4320-bc1d-d39546ca4f44"
+    }
+  ]
 }

--- a/data/raw/datasets/a480fd3f-d15b-408b-bc0a-51ed5db51adf.json
+++ b/data/raw/datasets/a480fd3f-d15b-408b-bc0a-51ed5db51adf.json
@@ -13,7 +13,7 @@
     "it": "Volumi annuali di uova a livello della catena di valore all'ingrosso/lavorazione"
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "marktanalysen@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft, Fachbereich Marktanalysen"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "7dd7f99f-4530-49f7-b191-f18cda34b032"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "quantity",
@@ -78,5 +71,11 @@
   "dct:temporal": {
     "dcat:start_date": "2016-01-01",
     "dcat:end_date": "2024-01-01"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "7dd7f99f-4530-49f7-b191-f18cda34b032"
+    }
+  ]
 }

--- a/data/raw/datasets/a5dce9aa-6eb8-430e-9126-9436f6c3aec1.json
+++ b/data/raw/datasets/a5dce9aa-6eb8-430e-9126-9436f6c3aec1.json
@@ -13,7 +13,7 @@
     "it": "I quattro fogli della carta in scala 1:200 000 forniscono una valutazione d'insieme delle condizioni climatiche e delle restrizioni relative all'agricoltura, suddivise in 20 categorie. La carta intende sottolineare le differenze di rilievo relative alle possibilità di coltivazione esistenti nelle singole regioni."
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "info@blw.admin.ch",
     "schema:name": "info@blw.admin.ch"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "3a56c453-d097-4f13-9435-531df2875d3c"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "cultivation-suitability",
@@ -162,6 +155,12 @@
       },
       "dct:license": "terms_by",
       "schema:comment": "ID for this distribution on opendata.swiss: cf863e7f-a467-47d7-a5e1-111148d3d9b3"
+    }
+  ],
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "3a56c453-d097-4f13-9435-531df2875d3c"
     }
   ]
 }

--- a/data/raw/datasets/a791ff06-0bb2-4d7a-814f-ec9740d208c2.json
+++ b/data/raw/datasets/a791ff06-0bb2-4d7a-814f-ec9740d208c2.json
@@ -13,7 +13,7 @@
     "it": ""
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "alessandro.rossi@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "e70d7954-d897-44d5-be15-54b05720f89c"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [],
   "dcat:theme": [
@@ -114,5 +107,11 @@
   "dct:temporal": {
     "dcat:start_date": "2014-01-01",
     "dcat:end_date": "2015-12-31"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "e70d7954-d897-44d5-be15-54b05720f89c"
+    }
+  ]
 }

--- a/data/raw/datasets/a88a2dfa-f5fb-4fe2-a1c5-af392052f6a2.json
+++ b/data/raw/datasets/a88a2dfa-f5fb-4fe2-a1c5-af392052f6a2.json
@@ -25,7 +25,7 @@
   "dct:accrualPeriodicity": "NEVER",
   "dct:modified": "2023-01-01",
   "bv:abrogation": "2023-12-31",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "bv:archivalValue": false,
   "prov:qualifiedAttribution": [
     {
@@ -41,14 +41,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:typeOfData": "referenceData",
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": false
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "BLW_CD_TDE_DueV_pre24",
-    "dcat:accessURL": "https://www.i14y.admin.ch/de/catalog/concepts/08dca65f-2d5e-9e75-8a13-48b8ecd20149"
-  },
   "dcat:theme": [
     "agriculture",
     "territory"
@@ -99,5 +91,6 @@
       "dct:format": "CSV",
       "dct:license": "terms_by"
     }
-  ]
+  ],
+  "bv:externalCatalogs": null
 }

--- a/data/raw/datasets/aa213bfe-c355-4c8e-a487-924b29d97e01.json
+++ b/data/raw/datasets/aa213bfe-c355-4c8e-a487-924b29d97e01.json
@@ -21,7 +21,7 @@
   ],
   "dct:accrualPeriodicity": "AS_NEEDED",
   "dct:modified": "2025-02-01",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "agis@blw.admin.ch",
     "schema:name": "Fachbereich Agrarinformationssysteme"
@@ -41,14 +41,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:typeOfData": "referenceData",
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": false
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "BLW_CD_agis_aquaculture",
-    "dcat:accessURL": "https://www.i14y.admin.ch/de/catalog/concepts/08dd50de-ea53-b497-8a45-39bd23beff61"
-  },
   "dcat:theme": [
     "agriculture"
   ],
@@ -99,5 +91,6 @@
       "dct:format": "CSV",
       "dct:license": "terms_by"
     }
-  ]
+  ],
+  "bv:externalCatalogs": null
 }

--- a/data/raw/datasets/aab5736f-f6d7-41ba-9de3-51f962bde65c.json
+++ b/data/raw/datasets/aab5736f-f6d7-41ba-9de3-51f962bde65c.json
@@ -13,7 +13,7 @@
     "it": "Prezzi medi mensili delle uova e di una selezione di prodotti a base di uova nella fase di consumo della catena del valore"
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "marktanalysen@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft, Fachbereich Marktanalysen"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "09bea124-7d41-40c8-bb1b-fc99afee456b"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "price",
@@ -78,5 +71,11 @@
   "dct:temporal": {
     "dcat:start_date": "2020-01-01",
     "dcat:end_date": "2024-12-01"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "09bea124-7d41-40c8-bb1b-fc99afee456b"
+    }
+  ]
 }

--- a/data/raw/datasets/aac232d4-3d80-44dc-a7df-ce3b72b94c20.json
+++ b/data/raw/datasets/aac232d4-3d80-44dc-a7df-ce3b72b94c20.json
@@ -13,7 +13,7 @@
     "it": "Il Registro delle denominazioni di origine (DOP) e delle indicazioni geografiche (IGP) consente di tutelare i nomi geografici e tradizionali che designano prodotti agricoli (ad eccezione del vino) la cui qualità e le cui caratteristiche principali sono determinate dalla loro origine. L'utilizzo di un nome protetto è appannaggio dei produttori della zona geografica definita che ottemperano ad un dettagliato elenco degli obblighi. La protezione di determinate denominazioni di prodotti agricoli è finalizzata a tutelare i consumatori dalle frodi e a proteggere i contadini dalla concorrenza sleale dovuta all'abuso delle denominazioni. La regolamentazione applicabile in questo settore permette il reciproco riconoscimento dei prodotti di qualità tra Svizzera e UE. Le DOP/IGP sono suddivise in quattro categorie: formaggi, prodotti carnei, prodotti vegetali e distillati. Attualmente il registro delle DOP/IGP conta 30 prodotti e il numero di registrazioni è in costante aumento."
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "info@blw.admin.ch",
     "schema:name": "info@blw.admin.ch"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "621e488c-7a97-46ca-9635-7afc2ab5266e"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "protected-geographical-indication",
@@ -167,6 +160,12 @@
       },
       "dct:license": "terms_by",
       "schema:comment": "ID for this distribution on opendata.swiss: 03029371-d3ed-4647-b2e1-69131b25a49d"
+    }
+  ],
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "621e488c-7a97-46ca-9635-7afc2ab5266e"
     }
   ]
 }

--- a/data/raw/datasets/ad68ced9-d7da-4817-980e-f439c7394172.json
+++ b/data/raw/datasets/ad68ced9-d7da-4817-980e-f439c7394172.json
@@ -14,7 +14,7 @@
   },
   "dct:accessRights": "RESTRICTED",
   "dct:issued": "2020-01-01",
-  "dct:publisher": "BLW-OFAG-UFAG",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:name": "AV MAF, GRKDT",
     "schema:email": "maf@blw.admin.ch"
@@ -25,9 +25,9 @@
     "meine-agrardaten-freigabe",
     "MAF",
     "structural-data",
-	"crops",
-	"BFF",
-	"NHG"
+    "crops",
+    "BFF",
+    "NHG"
   ],
   "dct:accrualPeriodicity": "ANNUAL",
   "dct:modified": "2025-03-25",
@@ -45,19 +45,13 @@
   "foaf:page": [
     {
       "alias": "PDF: MAF-Verfügbare Datenpakete",
-	  "uri": "https://backend.blw.admin.ch/fileservice/sdweb-docs-prod-blwch-files/files/2024/08/28/3106f5f5-1bcb-4b25-a78a-75c712f2491f.pdf"
+      "uri": "https://backend.blw.admin.ch/fileservice/sdweb-docs-prod-blwch-files/files/2024/08/28/3106f5f5-1bcb-4b25-a78a-75c712f2491f.pdf"
     }
   ],
   "adms:status": "published",
   "bv:classification": "none",
   "bv:personalData": "personalData",
   "bv:typeOfData": "thematicData",
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": false
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "dcat:theme": [
     "agriculture"
   ],
@@ -68,41 +62,42 @@
   "dcat:distribution": [
     {
       "dct:identifier": "5f4f43c6-0549-46df-9319-df163cba47d5",
-	  "dct:title": {
-		"de": "Flächenangaben zu Biodiversitätsfrderflächen auf einem Betrieb in der Schweizer Landwirtschaft",
-		"fr": "Indications de surface pour les surfaces de promotion de la biodiversité dans une exploitation agricole suisse",
-		"it": "Dati sulle superfici delle superfici per la promozione della biodiversità in un'azienda agricola in Svizzera",
-		"en": "Information on the area of biodiversity promotion areas on a farm in Swiss agriculture"
-	  },
-	  "dct:description": {
-		"de": "Dieses Datenpaket enthält die Daten zu Biodiversitätsförderflächen gemäss Direktzahlungsverordnung (DZV). Zu den Flächen wird die Zone, Hauptkultur, Fläche, Qualität BFF, NHG und Betrieb angegeben. Das Dataset enthält jährlich ab ca. Mitte März die Daten aus dem Vorjahr.",
-		"fr": "Ce paquet de données contient les données relatives aux surfaces de promotion de la biodiversité conformément à l'ordonnance sur les paiements directs (OPD). Pour les surfaces, la zone, la culture principale, la surface, la qualité SPB, la LPN et l'exploitation sont indiquées. L'ensemble de données contient chaque année, à partir de la mi-mars environ, les données de l'année précédente.",
-		"it": "Questo pacchetto di dati contiene i dati relativi alle superfici per la promozione della biodiversità ai sensi dell'ordinanza sui pagamenti diretti (OPD). Per le superfici vengono indicati la zona, la coltura principale, la superficie, la qualità SPB, la LPN e l'azienda. Il set di dati contiene i dati dell'anno precedente a partire da circa metà marzo di ogni anno.",
-		"en": "This data package contains the data on biodiversity promotion areas in accordance with the Swiss Direct Payments Ordinance (DPO). The zone, main crop, area, quality of BFF, NHG and farm are indicated for the areas. The dataset contains data from the previous year, available annually from around mid-March."
-	  },
+      "dct:title": {
+        "de": "Flächenangaben zu Biodiversitätsfrderflächen auf einem Betrieb in der Schweizer Landwirtschaft",
+        "fr": "Indications de surface pour les surfaces de promotion de la biodiversité dans une exploitation agricole suisse",
+        "it": "Dati sulle superfici delle superfici per la promozione della biodiversità in un'azienda agricola in Svizzera",
+        "en": "Information on the area of biodiversity promotion areas on a farm in Swiss agriculture"
+      },
+      "dct:description": {
+        "de": "Dieses Datenpaket enthält die Daten zu Biodiversitätsförderflächen gemäss Direktzahlungsverordnung (DZV). Zu den Flächen wird die Zone, Hauptkultur, Fläche, Qualität BFF, NHG und Betrieb angegeben. Das Dataset enthält jährlich ab ca. Mitte März die Daten aus dem Vorjahr.",
+        "fr": "Ce paquet de données contient les données relatives aux surfaces de promotion de la biodiversité conformément à l'ordonnance sur les paiements directs (OPD). Pour les surfaces, la zone, la culture principale, la surface, la qualité SPB, la LPN et l'exploitation sont indiquées. L'ensemble de données contient chaque année, à partir de la mi-mars environ, les données de l'année précédente.",
+        "it": "Questo pacchetto di dati contiene i dati relativi alle superfici per la promozione della biodiversità ai sensi dell'ordinanza sui pagamenti diretti (OPD). Per le superfici vengono indicati la zona, la coltura principale, la superficie, la qualità SPB, la LPN e l'azienda. Il set di dati contiene i dati dell'anno precedente a partire da circa metà marzo di ogni anno.",
+        "en": "This data package contains the data on biodiversity promotion areas in accordance with the Swiss Direct Payments Ordinance (DPO). The zone, main crop, area, quality of BFF, NHG and farm are indicated for the areas. The dataset contains data from the previous year, available annually from around mid-March."
+      },
       "adms:status": "published",
       "dct:modified": "2025-03-25",
       "dcat:accessURL": "https://www.blw.admin.ch/de/meine-agrardatenfreigabe",
       "dct:format": "CSV"
     },
-	{
+    {
       "dct:identifier": "73ddfb1f-0801-4809-afd4-7ba7eb8f905c",
-	  "dct:title": {
-		"de": "Flächenangaben zu Biodiversitätsfrderflächen auf einem Betrieb in der Schweizer Landwirtschaft - Provisorische Daten",
-		"fr": "Indications de surface pour les surfaces de promotion de la biodiversité dans une exploitation agricole suisse - données provisoires",
-		"it": "Dati sulle superfici delle superfici per la promozione della biodiversità in un'azienda agricola in Svizzera - dati provvisori",
-		"en": "Information on the area of biodiversity promotion areas on a farm in Swiss agriculture - provisional data"
-	  },
-	  "dct:description": {
-		"de": "Dieses Datenpaket enthält die Daten zu Biodiversitätsförderflächen gemäss Direktzahlungsverordnung (DZV). Zu den Flächen wird die Zone, Hauptkultur, Fläche, Qualität BFF, NHG und Betrieb angegeben. Das Dataset mit \"provisorischen Daten\" enthält Angaben aus dem laufenden Kalenderjahr.",
-		"fr": "Ce paquet de données contient les données relatives aux surfaces de promotion de la biodiversité conformément à l'ordonnance sur les paiements directs (OPD). Pour les surfaces, la zone, la culture principale, la surface, la qualité SPB, la LPN et l'exploitation sont indiquées. L'ensemble de données contenant les « données provisoires » contient des informations sur l'année civile en cours.",
-		"it": "Questo pacchetto di dati contiene i dati relativi alle superfici per la promozione della biodiversità ai sensi dell'ordinanza sui pagamenti diretti (OPD). Per le superfici vengono indicati la zona, la coltura principale, la superficie, la qualità SPB, la LPN e l'azienda. Il set di dati con \"dati provvisori\" contiene informazioni relative all'anno solare in corso.",
-		"en": "This data package contains the data on biodiversity promotion areas in accordance with the Swiss Direct Payments Ordinance (DPO). The zone, main crop, area, quality of BFF, NHG and farm are indicated for the areas. The dataset with \"provisional data\" contains information from the current calendar year."
-	  },
+      "dct:title": {
+        "de": "Flächenangaben zu Biodiversitätsfrderflächen auf einem Betrieb in der Schweizer Landwirtschaft - Provisorische Daten",
+        "fr": "Indications de surface pour les surfaces de promotion de la biodiversité dans une exploitation agricole suisse - données provisoires",
+        "it": "Dati sulle superfici delle superfici per la promozione della biodiversità in un'azienda agricola in Svizzera - dati provvisori",
+        "en": "Information on the area of biodiversity promotion areas on a farm in Swiss agriculture - provisional data"
+      },
+      "dct:description": {
+        "de": "Dieses Datenpaket enthält die Daten zu Biodiversitätsförderflächen gemäss Direktzahlungsverordnung (DZV). Zu den Flächen wird die Zone, Hauptkultur, Fläche, Qualität BFF, NHG und Betrieb angegeben. Das Dataset mit \"provisorischen Daten\" enthält Angaben aus dem laufenden Kalenderjahr.",
+        "fr": "Ce paquet de données contient les données relatives aux surfaces de promotion de la biodiversité conformément à l'ordonnance sur les paiements directs (OPD). Pour les surfaces, la zone, la culture principale, la surface, la qualité SPB, la LPN et l'exploitation sont indiquées. L'ensemble de données contenant les « données provisoires » contient des informations sur l'année civile en cours.",
+        "it": "Questo pacchetto di dati contiene i dati relativi alle superfici per la promozione della biodiversità ai sensi dell'ordinanza sui pagamenti diretti (OPD). Per le superfici vengono indicati la zona, la coltura principale, la superficie, la qualità SPB, la LPN e l'azienda. Il set di dati con \"dati provvisori\" contiene informazioni relative all'anno solare in corso.",
+        "en": "This data package contains the data on biodiversity promotion areas in accordance with the Swiss Direct Payments Ordinance (DPO). The zone, main crop, area, quality of BFF, NHG and farm are indicated for the areas. The dataset with \"provisional data\" contains information from the current calendar year."
+      },
       "adms:status": "published",
       "dct:modified": "2025-03-25",
       "dcat:accessURL": "https://www.blw.admin.ch/de/meine-agrardatenfreigabe",
       "dct:format": "CSV"
     }
-  ]
+  ],
+  "bv:externalCatalogs": null
 }

--- a/data/raw/datasets/ae2a7447-6ca1-4ea8-8024-6a7690f0c385.json
+++ b/data/raw/datasets/ae2a7447-6ca1-4ea8-8024-6a7690f0c385.json
@@ -13,7 +13,7 @@
     "it": "Si tratta dell'acqua ritenuta dal suolo attraverso le forze di tensione e facilmente assimilabile dai vegetali (0,1 - 1,0 atm). Si può stimare approssimativamente che per ogni cm di profondità fisiologica è facilmente assimilabile 1 mm d'acqua. La profondità fisiologica si calcola sottraendo dallo strato penetrabile dalle radici lo scheletro, grandi cavità dei suoli sabbioso-ghiaiosi, strutture compatte e orizzonti poveri di ossigeno. (Dettagli: carta delle attitudini dei suoli svizzeri, marzo 1980)."
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "info@blw.admin.ch",
     "schema:name": "info@blw.admin.ch"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "f3ea03ee-9d4c-431f-9ca3-f38746373fc0"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "cultivation-suitability",
@@ -161,6 +154,12 @@
       },
       "dct:license": "terms_by",
       "schema:comment": "ID for this distribution on opendata.swiss: 0d8f534b-b038-45fc-b414-955343931281"
+    }
+  ],
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "f3ea03ee-9d4c-431f-9ca3-f38746373fc0"
     }
   ]
 }

--- a/data/raw/datasets/ae627091-0ca2-4cdd-a83d-2bef90f78701.json
+++ b/data/raw/datasets/ae627091-0ca2-4cdd-a83d-2bef90f78701.json
@@ -13,7 +13,7 @@
     "it": ""
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "alessandro.rossi@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "73879228-7de8-4797-89d2-c089c9a07a21"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [],
   "dcat:theme": [
@@ -114,5 +107,11 @@
   "dct:temporal": {
     "dcat:start_date": "2014-01-01",
     "dcat:end_date": "2015-12-31"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "73879228-7de8-4797-89d2-c089c9a07a21"
+    }
+  ]
 }

--- a/data/raw/datasets/b086f7a6-c888-44db-a432-c87c94a3fbb2.json
+++ b/data/raw/datasets/b086f7a6-c888-44db-a432-c87c94a3fbb2.json
@@ -21,7 +21,7 @@
   "dcatap:availability": "EXPERIMENTAL",
   "bv:classification": "confidential",
   "bv:personalData": "personalData",
-  "dct:publisher": "BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "prov:qualifiedAttribution": [
     {
       "dcat:hadRole": "businessDataOwner"
@@ -35,10 +35,5 @@
   },
   "bv:abrogation": "",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": false
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": false
-  }
+  "bv:externalCatalogs": null
 }

--- a/data/raw/datasets/b1cfe652-688a-4898-9b29-ac0ff6bb13a7.json
+++ b/data/raw/datasets/b1cfe652-688a-4898-9b29-ac0ff6bb13a7.json
@@ -13,7 +13,7 @@
     "it": "Prezzi medi mensili per cereali panificabili, farina e prodotti da forno al livello del consumo"
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "marktanalysen@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft, Fachbereich Marktanalysen"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "ae43c729-da24-4d82-a3ae-01d13197833f"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "market-data",
@@ -78,5 +71,11 @@
   "dct:temporal": {
     "dcat:start_date": "2020-01-01",
     "dcat:end_date": "2024-10-01"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "ae43c729-da24-4d82-a3ae-01d13197833f"
+    }
+  ]
 }

--- a/data/raw/datasets/b2bbf16b-744d-4554-bc39-5528a7d59002.json
+++ b/data/raw/datasets/b2bbf16b-744d-4554-bc39-5528a7d59002.json
@@ -13,7 +13,7 @@
     "it": "Prezzi medi mensili delle uova nella fase di produzione della catena di valore"
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "marktanalysen@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft, Fachbereich Marktanalysen"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "0c5885ce-c147-4cfd-85cb-1279298860b0"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "market-data",
@@ -78,5 +71,11 @@
   "dct:temporal": {
     "dcat:start_date": "2016-01-01",
     "dcat:end_date": "2025-01-01"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "0c5885ce-c147-4cfd-85cb-1279298860b0"
+    }
+  ]
 }

--- a/data/raw/datasets/b5158cde-a426-4c7f-9a61-2f6a192938a2.json
+++ b/data/raw/datasets/b5158cde-a426-4c7f-9a61-2f6a192938a2.json
@@ -13,7 +13,7 @@
     "it": ""
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "alessandro.rossi@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "821dc562-2643-4b74-a69d-e532d8b4f6f9"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [],
   "dcat:theme": [
@@ -114,5 +107,11 @@
   "dct:temporal": {
     "dcat:start_date": "1990-01-01",
     "dcat:end_date": "2015-12-31"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "821dc562-2643-4b74-a69d-e532d8b4f6f9"
+    }
+  ]
 }

--- a/data/raw/datasets/b5c6b98b-c881-4535-8550-dac7096daba3.json
+++ b/data/raw/datasets/b5c6b98b-c881-4535-8550-dac7096daba3.json
@@ -13,7 +13,7 @@
     "it": "I quattro fogli della carta in scala 1:200 000 forniscono una valutazione d'insieme delle condizioni climatiche e delle restrizioni relative all'agricoltura, suddivise in 20 categorie. La carta intende sottolineare le differenze di rilievo relative alle possibilità di coltivazione esistenti nelle singole regioni."
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "info@blw.admin.ch",
     "schema:name": "info@blw.admin.ch"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "9c8fc590-4032-4356-9af9-42b7728217ae"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "cultivation-suitability",
@@ -162,6 +155,12 @@
       },
       "dct:license": "terms_by",
       "schema:comment": "ID for this distribution on opendata.swiss: 58a42b7e-56a2-437f-a690-3a8bd67423aa"
+    }
+  ],
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "9c8fc590-4032-4356-9af9-42b7728217ae"
     }
   ]
 }

--- a/data/raw/datasets/b732392b-e688-4ed5-9d5c-4399461e9259.json
+++ b/data/raw/datasets/b732392b-e688-4ed5-9d5c-4399461e9259.json
@@ -13,7 +13,7 @@
     "it": ""
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "alessandro.rossi@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "01678041-4c8d-47c9-8a9b-a83153947dfe"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [],
   "dcat:theme": [
@@ -114,5 +107,11 @@
   "dct:temporal": {
     "dcat:start_date": "1990-01-01",
     "dcat:end_date": "2015-12-31"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "01678041-4c8d-47c9-8a9b-a83153947dfe"
+    }
+  ]
 }

--- a/data/raw/datasets/b7845e61-ab2e-4153-8c6f-b524fb3cb4b8.json
+++ b/data/raw/datasets/b7845e61-ab2e-4153-8c6f-b524fb3cb4b8.json
@@ -13,7 +13,7 @@
     "it": ""
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "alessandro.rossi@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "0b2046ac-dbc6-467c-8456-898c8b8862f0"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [],
   "dcat:theme": [
@@ -114,5 +107,11 @@
   "dct:temporal": {
     "dcat:start_date": "2000-01-01",
     "dcat:end_date": "2016-12-31"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "0b2046ac-dbc6-467c-8456-898c8b8862f0"
+    }
+  ]
 }

--- a/data/raw/datasets/b7f151dc-8a3d-4d52-912b-6074be50fd70.json
+++ b/data/raw/datasets/b7f151dc-8a3d-4d52-912b-6074be50fd70.json
@@ -23,7 +23,7 @@
   ],
   "dct:accrualPeriodicity": "AS_NEEDED",
   "dct:modified": "2024-01-01",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "agis@blw.admin.ch",
     "schema:name": "Fachbereich Agrarinformationssysteme"
@@ -43,14 +43,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:typeOfData": "referenceData",
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": false
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "BLW_CD_DZ_CROP",
-    "dcat:accessURL": "https://www.i14y.admin.ch/de/catalog/concepts/08dcabe2-1734-ca16-9dfe-262056c9c124"
-  },
   "dcat:theme": [
     "agriculture",
     "territory",
@@ -103,5 +95,6 @@
       "dct:format": "CSV",
       "dct:license": "terms_by"
     }
-  ]
+  ],
+  "bv:externalCatalogs": null
 }

--- a/data/raw/datasets/b8cb3b68-0fb4-46d1-a309-23e4e3bbc856.json
+++ b/data/raw/datasets/b8cb3b68-0fb4-46d1-a309-23e4e3bbc856.json
@@ -13,7 +13,7 @@
     "it": "I quattro fogli della carta in scala 1:200 000 forniscono una valutazione d'insieme delle condizioni climatiche e delle restrizioni relative all'agricoltura, suddivise in 20 categorie. La carta intende sottolineare le differenze di rilievo relative alle possibilità di coltivazione esistenti nelle singole regioni."
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "info@blw.admin.ch",
     "schema:name": "info@blw.admin.ch"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "201f5121-9f69-48e0-bd7f-c22d7b9fd272"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "cultivation-suitability",
@@ -162,6 +155,12 @@
       },
       "dct:license": "terms_by",
       "schema:comment": "ID for this distribution on opendata.swiss: 9627a176-c167-4488-9cbf-66b2b233eb9b"
+    }
+  ],
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "201f5121-9f69-48e0-bd7f-c22d7b9fd272"
     }
   ]
 }

--- a/data/raw/datasets/b990b028-d113-42a1-9435-a7ffd0f00e48.json
+++ b/data/raw/datasets/b990b028-d113-42a1-9435-a7ffd0f00e48.json
@@ -13,7 +13,7 @@
     "it": "Sulla carta delle attitudini dei suoli ogni unità cartografica è dotata di un codice composto da una lettera maiuscola e da un numero. Le lettere rappresentano 25 unità fisiografiche differenti. Il numero indica diversi elementi formali dei paesaggi, ordinati in base a roccia madre, esposizione e declività. Inoltre, ogni unità cartografica contiene una o più tipologie di suolo. Le 144 unità cartografiche totali sono classificate, secondo l'attitudine del suolo, in 18 gruppi caratterizzati da colori differenti. Questa classificazione si basa essenzialmente su criteri di tipo agricolo."
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "info@blw.admin.ch",
     "schema:name": "info@blw.admin.ch"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "71f80b15-f866-47d1-b2b6-be96ae6d7189"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "cultivation-suitability",
@@ -161,6 +154,12 @@
       },
       "dct:license": "terms_by",
       "schema:comment": "ID for this distribution on opendata.swiss: afbc83b0-8b3d-4ded-8bda-e4d8cf34e79e"
+    }
+  ],
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "71f80b15-f866-47d1-b2b6-be96ae6d7189"
     }
   ]
 }

--- a/data/raw/datasets/bb7894e3-0dbf-4ea1-9e97-813936154238.json
+++ b/data/raw/datasets/bb7894e3-0dbf-4ea1-9e97-813936154238.json
@@ -13,7 +13,7 @@
     "it": "Per tenere opportunamente conto di condizioni di produzione e di vita difficili nell'agricoltura, vengono corrisposti contributi di declività per superfici che danno diritto a pagamenti diretti. Per i pagamenti diretti generali è stato creato un set di dati \"Zone declive\" (OGI 152.1; OPD art. 43) e un secondo set di dati \"Vigneti in zone declive\" (OGI 152.2; OPD art. 45). Sono previste diverse classi di declività. Il set di dati \"Zone declive\" fa parte delle basi di calcolo per i pagamenti diretti agricoli, applicando un sistema d'informazione geografica SIG. I calcoli sono stati effettuati secondo criteri unitari per tutta la Svizzera. La produzione si basa sul modello del terreno \"SwissAlti3D\" di swisstopo. Si distinguono le seguenti classi di declività: <18; 18-35; 35-50; >50 per cento. Le superfici declive inferiori a un'ara non sono state considerate."
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "info@blw.admin.ch",
     "schema:name": "info@blw.admin.ch"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "6cac5c48-29b1-45d0-b684-836ac6354be3"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "official-geodata",
@@ -143,6 +136,12 @@
       },
       "dct:license": "terms_by",
       "schema:comment": "ID for this distribution on opendata.swiss: 94c72b1f-bb7f-41a1-b2a9-88e7c12bacca"
+    }
+  ],
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "6cac5c48-29b1-45d0-b684-836ac6354be3"
     }
   ]
 }

--- a/data/raw/datasets/bda83b03-5ecc-41b0-a822-4a2d17d02dc2.json
+++ b/data/raw/datasets/bda83b03-5ecc-41b0-a822-4a2d17d02dc2.json
@@ -13,7 +13,7 @@
     "it": ""
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "alessandro.rossi@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "936c8f63-3d24-42ef-bcc4-75505ae7cd5d"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [],
   "dcat:theme": [
@@ -114,5 +107,11 @@
   "dct:temporal": {
     "dcat:start_date": "2014-01-01",
     "dcat:end_date": "2015-12-31"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "936c8f63-3d24-42ef-bcc4-75505ae7cd5d"
+    }
+  ]
 }

--- a/data/raw/datasets/c2e3fe68-850e-4666-8d79-28d46382e611.json
+++ b/data/raw/datasets/c2e3fe68-850e-4666-8d79-28d46382e611.json
@@ -13,7 +13,7 @@
     "it": "La permeabilità è misurata in laboratorio su campioni cilindrici saturi. Le osservazioni del terreno consentono di stabilire correlazioni tra le precipitazioni, la permeabilità e i tratti morfologici. È stato considerato l'orizzone meno permeabile dei 50 cm superiori. (Dettagli: carta delle attitudini dei suoli svizzeri, marzo 1980)."
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "info@blw.admin.ch",
     "schema:name": "info@blw.admin.ch"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "6d44898a-5519-4ab0-a426-9641c0741faf"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "cultivation-suitability",
@@ -161,6 +154,12 @@
       },
       "dct:license": "terms_by",
       "schema:comment": "ID for this distribution on opendata.swiss: cc1f7892-35e6-4e3f-ace9-021ed3bdff2b"
+    }
+  ],
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "6d44898a-5519-4ab0-a426-9641c0741faf"
     }
   ]
 }

--- a/data/raw/datasets/c3b38cf5-8f64-406b-8ecf-4858916b5a50.json
+++ b/data/raw/datasets/c3b38cf5-8f64-406b-8ecf-4858916b5a50.json
@@ -13,7 +13,7 @@
     "it": "Quantità annue per cereali panificabili, farina e prodotti da forno al livello di produzione"
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "marktanalysen@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft, Fachbereich Marktanalysen"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "e6b9a0ec-6ecf-4d72-a8ce-c95e2b22235a"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "market-data",
@@ -78,5 +71,11 @@
   "dct:temporal": {
     "dcat:start_date": "2014-07-01",
     "dcat:end_date": "2023-07-01"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "e6b9a0ec-6ecf-4d72-a8ce-c95e2b22235a"
+    }
+  ]
 }

--- a/data/raw/datasets/c3d2908f-707f-43cd-95e7-d134f2059524.json
+++ b/data/raw/datasets/c3d2908f-707f-43cd-95e7-d134f2059524.json
@@ -13,7 +13,7 @@
     "it": "Il Registro delle denominazioni di origine (DOP) e delle indicazioni geografiche (IGP) consente di tutelare i nomi geografici e tradizionali che designano prodotti agricoli (ad eccezione del vino) la cui qualità e le cui caratteristiche principali sono determinate dalla loro origine. L'utilizzo di un nome protetto è appannaggio dei produttori della zona geografica definita che ottemperano ad un dettagliato elenco degli obblighi. La protezione di determinate denominazioni di prodotti agricoli è finalizzata a tutelare i consumatori dalle frodi e a proteggere i contadini dalla concorrenza sleale dovuta all'abuso delle denominazioni. La regolamentazione applicabile in questo settore permette il reciproco riconoscimento dei prodotti di qualità tra Svizzera e UE. Le DOP/IGP sono suddivise in quattro categorie: formaggi, prodotti carnei, prodotti vegetali e distillati. Attualmente il registro delle DOP/IGP conta 30 prodotti e il numero di registrazioni è in costante aumento."
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "info@blw.admin.ch",
     "schema:name": "info@blw.admin.ch"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "131b59a3-e269-4e86-a3c1-d8cee5be7aac"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "protected-designation-of-origin",
@@ -167,6 +160,12 @@
       },
       "dct:license": "terms_by",
       "schema:comment": "ID for this distribution on opendata.swiss: 76ced07d-8a5b-4ccd-b592-2daff707e340"
+    }
+  ],
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "131b59a3-e269-4e86-a3c1-d8cee5be7aac"
     }
   ]
 }

--- a/data/raw/datasets/c61f6636-f09f-433e-8612-4babd5a3a9f4.json
+++ b/data/raw/datasets/c61f6636-f09f-433e-8612-4babd5a3a9f4.json
@@ -26,7 +26,7 @@
   "dct:accrualPeriodicity": "NEVER",
   "dct:modified": "2023-01-01",
   "bv:abrogation": "2023-12-31",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "bv:archivalValue": false,
   "prov:qualifiedAttribution": [
     {
@@ -42,14 +42,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:typeOfData": "referenceData",
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": false
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "BLW_CD_TDE_DueV_pre24",
-    "dcat:accessURL": "https://www.i14y.admin.ch/de/catalog/concepts/08dca714-3c5e-6cb1-9f9c-1a1bd280af27"
-  },
   "dcat:theme": [
     "agriculture",
     "territory"
@@ -100,5 +92,6 @@
       "dct:format": "CSV",
       "dct:license": "terms_by"
     }
-  ]
+  ],
+  "bv:externalCatalogs": null
 }

--- a/data/raw/datasets/cc1d32c9-33e1-4f31-8a61-a27a74631ad5.json
+++ b/data/raw/datasets/cc1d32c9-33e1-4f31-8a61-a27a74631ad5.json
@@ -13,7 +13,7 @@
     "it": ""
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "alessandro.rossi@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "c8e2cf7b-182d-4d97-88f0-ea8e7c2b2745"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [],
   "dcat:theme": [
@@ -114,5 +107,11 @@
   "dct:temporal": {
     "dcat:start_date": "1990-01-01",
     "dcat:end_date": "2015-12-31"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "c8e2cf7b-182d-4d97-88f0-ea8e7c2b2745"
+    }
+  ]
 }

--- a/data/raw/datasets/cce23d00-7ae9-493e-b3af-5f72241a455c.json
+++ b/data/raw/datasets/cce23d00-7ae9-493e-b3af-5f72241a455c.json
@@ -14,7 +14,7 @@
     "it": "Prezzi medi annui delle oleaginose al livello del consumo"
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "marktanalysen@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft, Fachbereich Marktanalysen"
@@ -26,13 +26,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "6b11c466-5282-48d3-83bb-8c8348af2bf6"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "market-data",
@@ -80,5 +73,11 @@
   "dct:temporal": {
     "dcat:start_date": "2020-01-01",
     "dcat:end_date": "2024-01-01"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "6b11c466-5282-48d3-83bb-8c8348af2bf6"
+    }
+  ]
 }

--- a/data/raw/datasets/ce46b718-4217-47e3-8f4e-e81a34d2a923.json
+++ b/data/raw/datasets/ce46b718-4217-47e3-8f4e-e81a34d2a923.json
@@ -13,7 +13,7 @@
     "it": "Profondità del suolo penetrabile dalle radici (in generale radici sottili e spesse; non si tiene conto ad esempio delle radici che penetrano in fenditure). (Dettagli: carta delle attitudini dei suoli svizzeri, marzo 1980)."
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "info@blw.admin.ch",
     "schema:name": "info@blw.admin.ch"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "03e2cfdd-40c1-4fe0-bf34-5c15e5779559"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "cultivation-suitability",
@@ -161,6 +154,12 @@
       },
       "dct:license": "terms_by",
       "schema:comment": "ID for this distribution on opendata.swiss: e68e7981-1bc5-4e6b-8659-ef46b24c558a"
+    }
+  ],
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "03e2cfdd-40c1-4fe0-bf34-5c15e5779559"
     }
   ]
 }

--- a/data/raw/datasets/d1692003-f226-4d4c-b70d-baa3332bca82.json
+++ b/data/raw/datasets/d1692003-f226-4d4c-b70d-baa3332bca82.json
@@ -14,7 +14,7 @@
   },
   "dct:accessRights": "RESTRICTED",
   "dct:issued": "2020-01-01",
-  "dct:publisher": "BLW-OFAG-UFAG",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:name": "AV MAF, GRKDT",
     "schema:email": "maf@blw.admin.ch"
@@ -25,11 +25,11 @@
     "meine-agrardaten-freigabe",
     "MAF",
     "operational-data",
-	"register-data",
-	"operator",
-	"UID",
-	"animal-owner",
-	"legal-form"
+    "register-data",
+    "operator",
+    "UID",
+    "animal-owner",
+    "legal-form"
   ],
   "dct:accrualPeriodicity": "WEEKLY",
   "dct:modified": "2025-03-25",
@@ -47,19 +47,13 @@
   "foaf:page": [
     {
       "alias": "PDF: MAF-Verfügbare Datenpakete",
-	  "uri": "https://backend.blw.admin.ch/fileservice/sdweb-docs-prod-blwch-files/files/2024/08/28/3106f5f5-1bcb-4b25-a78a-75c712f2491f.pdf"
+      "uri": "https://backend.blw.admin.ch/fileservice/sdweb-docs-prod-blwch-files/files/2024/08/28/3106f5f5-1bcb-4b25-a78a-75c712f2491f.pdf"
     }
   ],
   "adms:status": "published",
   "bv:classification": "none",
   "bv:personalData": "personalData",
   "bv:typeOfData": "thematicData",
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": false
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "dcat:theme": [
     "agriculture"
   ],
@@ -70,22 +64,23 @@
   "dcat:distribution": [
     {
       "dct:identifier": "08916f4e-f185-4389-83b8-86827d936ba2",
-	  "dct:title": {
-		"de": "Juristische und natürliche Personen aus der Schweizerischen Landwirtschaft",
-		"fr": "Personnes morales et physiques issues du secteur agricole suisse",
-		"it": "Persone giuridiche e fisiche del settore agricolo svizzero",
-		"en": "Legal and natural persons in the Swiss agricultural sector"
-	  },
-	  "dct:description": {
-		"de": "Dieses Datenpaket enthält von Tierhaltern und Bewirtschaftern Angaben zur Person, wie: Name, Vorname, kantonale Personennummer, Postadresse, Telefon und Email, Rechtsform und zur Person zugehöriger Betrieb. Im BLW sind auf Anfrage über die Anwendung MAF aus dem System AGIS Betriebsdaten (Person und Betrieb), Strukturdaten und Anmeldedaten zu landwirtschaftlichen Betrieben verfügbar. Zur Weitergabe der Daten müssen die Bewirtschaftenden ihre Einwilligung in der Anwendung MAF erteilen. Diese dataset entschpricht den Datenpaket R01 \"Person\" aus dem MAF PDF-Katalog.",
-		"fr": "Ce paquet de données contient des informations personnelles sur les éleveurs et les exploitants, telles que : nom, prénom, numéro cantonal personnel, adresse postale, téléphone et e-mail, forme juridique et exploitation à laquelle la personne est rattachée. Sur demande, l'OFAG met à disposition des données d'exploitation (personne et exploitation), des données structurelles et des données d'enregistrement des exploitations agricoles via l'application MAF du système AGIS. Pour que les données puissent être transmises, les exploitants doivent donner leur consentement dans l'application MAF. Cet ensemble de données correspond au paquet de données R01 « Personne » du catalogue PDF MAF.",
-		"it": "Questo pacchetto di dati contiene informazioni personali di proprietari di animali e gestori, quali: cognome, nome, numero di persona cantonale, indirizzo postale, telefono ed e-mail, forma giuridica e azienda associata alla persona. Su richiesta, tramite l'applicazione MAF del sistema AGIS, l'UFAG mette a disposizione dati aziendali (persona e azienda), dati strutturali e dati di registrazione delle aziende agricole. Per la trasmissione dei dati, gli agricoltori devono dare il loro consenso nell'applicazione MAF. Questo dataset corrisponde al pacchetto di dati R01 “Persona” dal catalogo MAF PDF.",
-		"en": "This data package contains personal information from livestock owners and managers, such as: surname, first name, cantonal personal number, postal address, telephone and email, legal form and the person's associated company. The FOAG has access to operating data (person and company), structural data and registration data on agricultural companies via the MAF application from the AGIS system. Farm managers must give their consent in the MAF application for the data to be passed on. This dataset corresponds to the data package R01 \"Person\" from the MAF PDF catalogue."
-	  },
+      "dct:title": {
+        "de": "Juristische und natürliche Personen aus der Schweizerischen Landwirtschaft",
+        "fr": "Personnes morales et physiques issues du secteur agricole suisse",
+        "it": "Persone giuridiche e fisiche del settore agricolo svizzero",
+        "en": "Legal and natural persons in the Swiss agricultural sector"
+      },
+      "dct:description": {
+        "de": "Dieses Datenpaket enthält von Tierhaltern und Bewirtschaftern Angaben zur Person, wie: Name, Vorname, kantonale Personennummer, Postadresse, Telefon und Email, Rechtsform und zur Person zugehöriger Betrieb. Im BLW sind auf Anfrage über die Anwendung MAF aus dem System AGIS Betriebsdaten (Person und Betrieb), Strukturdaten und Anmeldedaten zu landwirtschaftlichen Betrieben verfügbar. Zur Weitergabe der Daten müssen die Bewirtschaftenden ihre Einwilligung in der Anwendung MAF erteilen. Diese dataset entschpricht den Datenpaket R01 \"Person\" aus dem MAF PDF-Katalog.",
+        "fr": "Ce paquet de données contient des informations personnelles sur les éleveurs et les exploitants, telles que : nom, prénom, numéro cantonal personnel, adresse postale, téléphone et e-mail, forme juridique et exploitation à laquelle la personne est rattachée. Sur demande, l'OFAG met à disposition des données d'exploitation (personne et exploitation), des données structurelles et des données d'enregistrement des exploitations agricoles via l'application MAF du système AGIS. Pour que les données puissent être transmises, les exploitants doivent donner leur consentement dans l'application MAF. Cet ensemble de données correspond au paquet de données R01 « Personne » du catalogue PDF MAF.",
+        "it": "Questo pacchetto di dati contiene informazioni personali di proprietari di animali e gestori, quali: cognome, nome, numero di persona cantonale, indirizzo postale, telefono ed e-mail, forma giuridica e azienda associata alla persona. Su richiesta, tramite l'applicazione MAF del sistema AGIS, l'UFAG mette a disposizione dati aziendali (persona e azienda), dati strutturali e dati di registrazione delle aziende agricole. Per la trasmissione dei dati, gli agricoltori devono dare il loro consenso nell'applicazione MAF. Questo dataset corrisponde al pacchetto di dati R01 “Persona” dal catalogo MAF PDF.",
+        "en": "This data package contains personal information from livestock owners and managers, such as: surname, first name, cantonal personal number, postal address, telephone and email, legal form and the person's associated company. The FOAG has access to operating data (person and company), structural data and registration data on agricultural companies via the MAF application from the AGIS system. Farm managers must give their consent in the MAF application for the data to be passed on. This dataset corresponds to the data package R01 \"Person\" from the MAF PDF catalogue."
+      },
       "adms:status": "published",
       "dct:modified": "2025-03-25",
       "dcat:accessURL": "https://www.blw.admin.ch/de/meine-agrardatenfreigabe",
       "dct:format": "CSV"
     }
-  ]
+  ],
+  "bv:externalCatalogs": null
 }

--- a/data/raw/datasets/d21435e2-83b4-48b6-a109-7b9827368e00.json
+++ b/data/raw/datasets/d21435e2-83b4-48b6-a109-7b9827368e00.json
@@ -13,7 +13,7 @@
     "it": "Prezzi medi annui e prezzi indicativi per cereali panificabili, farina e prodotti da forno al livello di produzione"
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "marktanalysen@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft, Fachbereich Marktanalysen"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "9beadde3-caa0-4e39-9676-357d375d79ab"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "price",
@@ -78,5 +71,11 @@
   "dct:temporal": {
     "dcat:start_date": "2010-07-01",
     "dcat:end_date": "2023-07-01"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "9beadde3-caa0-4e39-9676-357d375d79ab"
+    }
+  ]
 }

--- a/data/raw/datasets/d45b39cd-5317-400d-88cf-015ed690e76d.json
+++ b/data/raw/datasets/d45b39cd-5317-400d-88cf-015ed690e76d.json
@@ -13,7 +13,7 @@
     "it": "Struttura del mercato annuale delle uova in percentuale a livello della catena del valore produzione"
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "marktanalysen@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft, Fachbereich Marktanalysen"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "c49e3861-9b41-4e77-878e-1cead201bf9c"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "price",
@@ -78,5 +71,11 @@
   "dct:temporal": {
     "dcat:start_date": "2007-01-01",
     "dcat:end_date": "2024-01-01"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "c49e3861-9b41-4e77-878e-1cead201bf9c"
+    }
+  ]
 }

--- a/data/raw/datasets/d84c6d4f-dcd0-4473-993c-a35c657338ad.json
+++ b/data/raw/datasets/d84c6d4f-dcd0-4473-993c-a35c657338ad.json
@@ -13,7 +13,7 @@
     "it": "I quattro fogli della carta in scala 1:200 000 forniscono una valutazione d'insieme delle condizioni climatiche e delle restrizioni relative all'agricoltura, suddivise in 20 categorie. La carta intende sottolineare le differenze di rilievo relative alle possibilità di coltivazione esistenti nelle singole regioni."
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "info@blw.admin.ch",
     "schema:name": "info@blw.admin.ch"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "f22ad686-5387-4410-900c-8eb763dd16ce"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "cultivation-suitability",
@@ -162,6 +155,12 @@
       },
       "dct:license": "terms_by",
       "schema:comment": "ID for this distribution on opendata.swiss: bad68ff6-5c90-46e1-b5ee-feba44f0520a"
+    }
+  ],
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "f22ad686-5387-4410-900c-8eb763dd16ce"
     }
   ]
 }

--- a/data/raw/datasets/db1e64b5-2236-40a7-b84c-424b5937a1dd.json
+++ b/data/raw/datasets/db1e64b5-2236-40a7-b84c-424b5937a1dd.json
@@ -13,7 +13,7 @@
     "it": ""
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "alessandro.rossi@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "4723dc61-dd4c-4e1a-afc1-ec16f356123e"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [],
   "dcat:theme": [
@@ -114,5 +107,11 @@
   "dct:temporal": {
     "dcat:start_date": "2002-01-01",
     "dcat:end_date": "2015-12-31"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "4723dc61-dd4c-4e1a-afc1-ec16f356123e"
+    }
+  ]
 }

--- a/data/raw/datasets/db3bd925-f540-4c38-9a54-fb4fbe524609.json
+++ b/data/raw/datasets/db3bd925-f540-4c38-9a54-fb4fbe524609.json
@@ -22,7 +22,7 @@
   ],
   "dct:accrualPeriodicity": "AS_NEEDED",
   "dct:modified": "2024-01-01",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "agis@blw.admin.ch",
     "schema:name": "Fachbereich Agrarinformationssysteme"
@@ -42,14 +42,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:typeOfData": "referenceData",
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": false
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "BLW_CD_DZ_AREA",
-    "dcat:accessURL": "https://www.i14y.admin.ch/de/catalog/concepts/08dd50e5-da95-bba3-9ec9-f99d769eec6d"
-  },
   "dcat:theme": [
     "agriculture",
     "territory",
@@ -102,5 +94,6 @@
       "dct:format": "CSV",
       "dct:license": "terms_by"
     }
-  ]
+  ],
+  "bv:externalCatalogs": null
 }

--- a/data/raw/datasets/de36bb9d-ce43-48ea-8a8b-26bef7dee358.json
+++ b/data/raw/datasets/de36bb9d-ce43-48ea-8a8b-26bef7dee358.json
@@ -13,7 +13,7 @@
     "it": "Il set di geodati \"Superfici d’utilizzazione agricole\" mostra la localizzazione spaziale delle superfici coltivate come prati, pascoli e seminativi in Svizzera. Contiene le superfici utilizzate per l'agricoltura secondo l'Ordinanza sulla terminologia agricola (LBV), l'Ordinanza sui pagamenti diretti (DZV) e le definizioni (compresa la codifica) dell'uso del suolo derivate da queste dalla Confederazione e dai Cantoni. Il set di dati si basa sui geodati ufficiali della legislazione federale \"Superfici agricole coltivate\" (GeoIV, Allegato 1, identificatore 153), che sono di competenza dei Cantoni. Il set di dati viene aggiornato una volta all'anno."
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "info@blw.admin.ch",
     "schema:name": "info@blw.admin.ch"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "ccd6ff9b-b1e0-4328-acbc-dd139a79522d"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "land-use",
@@ -142,6 +135,12 @@
       },
       "dct:license": "terms_by",
       "schema:comment": "ID for this distribution on opendata.swiss: 82539356-f071-44db-929f-afa9cfefe87a"
+    }
+  ],
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "ccd6ff9b-b1e0-4328-acbc-dd139a79522d"
     }
   ]
 }

--- a/data/raw/datasets/dfd7ac55-4174-4671-b97a-80568aaf39a0.json
+++ b/data/raw/datasets/dfd7ac55-4174-4671-b97a-80568aaf39a0.json
@@ -13,7 +13,7 @@
     "it": "La raccolta di geodati di base delle zone e regioni agricole consiste in sei zone di produzione agricola e dalla regione d'estivazione e costituisce il catasto della produzione agricola. Questo rileva le condizioni di produzione e di vita difficili che occorre considerare opportunamente nell'applicazione della legge sull'agricoltura. Le basi giuridiche sono disciplinate dall'articolo 4 della legge sull'agricoltura (RS 910.1) nonché dall'ordinanza concernente il catasto della produzione agricola e la delimitazione di zone (RS 912.1). Diverse misure nel campo della legge sull'agricoltura si basano sulla suddivisone per zone. Una parte dei pagamenti diretti a favore dell'agricoltura, ad esempio, è differenziata in funzione dell'appartenenza a una determinata zona."
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "info@blw.admin.ch",
     "schema:name": "info@blw.admin.ch"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "704b25c2-1140-4bee-9df6-11901492232a"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "official-geodata",
@@ -123,6 +116,12 @@
       },
       "dct:license": "terms_by",
       "schema:comment": "ID for this distribution on opendata.swiss: d2f7c148-8338-4fa0-8475-8ee9fc8811f6"
+    }
+  ],
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "704b25c2-1140-4bee-9df6-11901492232a"
     }
   ]
 }

--- a/data/raw/datasets/e1e7eebc-26a8-4448-ac45-4a3136dad28b.json
+++ b/data/raw/datasets/e1e7eebc-26a8-4448-ac45-4a3136dad28b.json
@@ -13,7 +13,7 @@
     "it": "I quattro fogli della carta in scala 1:200 000 forniscono una valutazione d'insieme delle condizioni climatiche e delle restrizioni relative all'agricoltura, suddivise in 20 categorie. La carta intende sottolineare le differenze di rilievo relative alle possibilità di coltivazione esistenti nelle singole regioni."
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "info@blw.admin.ch",
     "schema:name": "info@blw.admin.ch"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "419b5e7e-98e2-4a14-bd58-178c1c9e4338"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "cultivation-suitability",
@@ -162,6 +155,12 @@
       },
       "dct:license": "terms_by",
       "schema:comment": "ID for this distribution on opendata.swiss: 85006380-7b50-448c-a11d-e53ecf5beb7b"
+    }
+  ],
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "419b5e7e-98e2-4a14-bd58-178c1c9e4338"
     }
   ]
 }

--- a/data/raw/datasets/e46f6fc7-90a2-4220-97e7-0311fcbaaf46.json
+++ b/data/raw/datasets/e46f6fc7-90a2-4220-97e7-0311fcbaaf46.json
@@ -13,7 +13,7 @@
     "it": "La carta delle vie di deflusso idrico riporta le nuove vie di deflusso idrico calcolate per il ruscellamento superficiale (coefficiente L dell’Universal Soil Loss Equation o della carta del rischio di erosione) sulle superfici agricole all’interno dei blocchi di particelle. Le vie di deflusso si basano sul modello del terreno SwissALTI3D e su algoritmi a flusso multiplo e raffigurano le aree in cui l’acqua si raccoglie e defluisce a causa della topografia. Più il colore è scuro, maggiore è la portata possibile e quindi il rischio di erosione. Con questa carta è possibile raffigurare chiaramente il rischio di erosione talweg e i possibili danni al di fuori del blocco di particelle (danni off-site), per esempio a strade e corsi d’acqua."
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "info@blw.admin.ch",
     "schema:name": "info@blw.admin.ch"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "b5bdff07-74bf-4dfa-b015-7e1aa2f2b422"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "soil",
@@ -137,6 +130,12 @@
       },
       "dct:license": "terms_by",
       "schema:comment": "ID for this distribution on opendata.swiss: 141b9f70-8942-415e-b52f-a02bf42d63e9"
+    }
+  ],
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "b5bdff07-74bf-4dfa-b015-7e1aa2f2b422"
     }
   ]
 }

--- a/data/raw/datasets/e4b1f944-2f1a-433e-bcd4-7f88028800c8.json
+++ b/data/raw/datasets/e4b1f944-2f1a-433e-bcd4-7f88028800c8.json
@@ -14,7 +14,7 @@
   },
   "dct:accessRights": "RESTRICTED",
   "dct:issued": "2020-01-01",
-  "dct:publisher": "BLW-OFAG-UFAG",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:name": "AV MAF, GRKDT",
     "schema:email": "maf@blw.admin.ch"
@@ -25,9 +25,9 @@
     "meine-agrardaten-freigabe",
     "MAF",
     "structural-data",
-	"crops",
-	"slope-gradient",
-	"vineyards"
+    "crops",
+    "slope-gradient",
+    "vineyards"
   ],
   "dct:accrualPeriodicity": "ANNUAL",
   "dct:modified": "2025-03-25",
@@ -45,19 +45,13 @@
   "foaf:page": [
     {
       "alias": "PDF: MAF-Verfügbare Datenpakete",
-	  "uri": "https://backend.blw.admin.ch/fileservice/sdweb-docs-prod-blwch-files/files/2024/08/28/3106f5f5-1bcb-4b25-a78a-75c712f2491f.pdf"
+      "uri": "https://backend.blw.admin.ch/fileservice/sdweb-docs-prod-blwch-files/files/2024/08/28/3106f5f5-1bcb-4b25-a78a-75c712f2491f.pdf"
     }
   ],
   "adms:status": "published",
   "bv:classification": "none",
   "bv:personalData": "personalData",
   "bv:typeOfData": "thematicData",
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": false
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "dcat:theme": [
     "agriculture"
   ],
@@ -68,41 +62,42 @@
   "dcat:distribution": [
     {
       "dct:identifier": "9a24783a-7f00-4654-8813-33cc53ac30d7",
-	  "dct:title": {
-		"de": "Flächenangaben zu Rebfächen in Hanglagen auf einem Betrieb in der Schweizer Landwirtschaft",
-		"fr": "Indications de surface pour les vignobles en pente sur une exploitation agricole suisse",
-		"it": "Dati sulle superfici di vigneti in pendenza in un'azienda agricola svizzera",
-		"en": "Information on the area of vineyards on slopes on a Swiss agricultural holding"
-	  },
-	  "dct:description": {
-		"de": "Dieses Datenpaket enthält Rebflächen, die in einem Hang liegen mit einer Neigung grösser als 30%. Zu den Flächen wird die Hauptkultur, Hangneigung, Zone und Betrieb angegeben. Das Dataset enthält jährlich ab ca. Mitte März die Daten aus dem Vorjahr.",
-		"fr": "Ce paquet de données contient les vignobles situés sur des pentes dont l'inclinaison est supérieure à 30 %. La culture principale, l'inclinaison de la pente, la zone et l'exploitation sont indiquées pour les surfaces. L'ensemble de données contient chaque année, à partir de la mi-mars environ, les données de l'année précédente.",
-		"it": "Questo pacchetto di dati contiene i vigneti situati su un pendio con una pendenza superiore al 30%. Per le superfici vengono indicati la coltura principale, la pendenza del pendio, la zona e l'azienda. Il set di dati contiene i dati dell'anno precedente a partire da circa metà marzo di ogni anno.",
-		"en": "This data set contains vineyard areas that are located on slopes with an inclination of more than 30%. The main crop, slope inclination, zone and farm are indicated for the areas. The dataset contains data from the previous year, available annually from around mid-March."
-	  },
+      "dct:title": {
+        "de": "Flächenangaben zu Rebfächen in Hanglagen auf einem Betrieb in der Schweizer Landwirtschaft",
+        "fr": "Indications de surface pour les vignobles en pente sur une exploitation agricole suisse",
+        "it": "Dati sulle superfici di vigneti in pendenza in un'azienda agricola svizzera",
+        "en": "Information on the area of vineyards on slopes on a Swiss agricultural holding"
+      },
+      "dct:description": {
+        "de": "Dieses Datenpaket enthält Rebflächen, die in einem Hang liegen mit einer Neigung grösser als 30%. Zu den Flächen wird die Hauptkultur, Hangneigung, Zone und Betrieb angegeben. Das Dataset enthält jährlich ab ca. Mitte März die Daten aus dem Vorjahr.",
+        "fr": "Ce paquet de données contient les vignobles situés sur des pentes dont l'inclinaison est supérieure à 30 %. La culture principale, l'inclinaison de la pente, la zone et l'exploitation sont indiquées pour les surfaces. L'ensemble de données contient chaque année, à partir de la mi-mars environ, les données de l'année précédente.",
+        "it": "Questo pacchetto di dati contiene i vigneti situati su un pendio con una pendenza superiore al 30%. Per le superfici vengono indicati la coltura principale, la pendenza del pendio, la zona e l'azienda. Il set di dati contiene i dati dell'anno precedente a partire da circa metà marzo di ogni anno.",
+        "en": "This data set contains vineyard areas that are located on slopes with an inclination of more than 30%. The main crop, slope inclination, zone and farm are indicated for the areas. The dataset contains data from the previous year, available annually from around mid-March."
+      },
       "adms:status": "published",
       "dct:modified": "2025-03-25",
       "dcat:accessURL": "https://www.blw.admin.ch/de/meine-agrardatenfreigabe",
       "dct:format": "CSV"
     },
-	{
+    {
       "dct:identifier": "4f0eef7b-633a-4a37-a795-9550cf0f7a1a",
-	  "dct:title": {
-		"de": "Flächenangaben zu Rebfächen in Hanglagen auf einem Betrieb in der Schweizer Landwirtschaft - Provisorische Daten",
-		"fr": "Indications de surface pour les vignobles en pente sur une exploitation agricole suisse - données provisoires",
-		"it": "Dati sulle superfici di vigneti in pendenza in un'azienda agricola svizzera - dati provvisori",
-		"en": "Information on the area of vineyards on slopes on a Swiss agricultural holding - provisional data"
-	  },
-	  "dct:description": {
-		"de": "Dieses Datenpaket enthält Rebflächen, die in einem Hang liegen mit einer Neigung grösser als 30%. Zu den Flächen wird die Hauptkultur, Hangneigung, Zone und Betrieb angegeben. Das Dataset mit \"provisorischen Daten\" enthält Angaben aus dem laufenden Kalenderjahr.",
-		"fr": "Ce paquet de données contient les vignobles situés sur des pentes dont l'inclinaison est supérieure à 30 %. La culture principale, l'inclinaison de la pente, la zone et l'exploitation sont indiquées pour les surfaces. L'ensemble de données contenant les « données provisoires » contient des informations sur l'année civile en cours.",
-		"it": "Questo pacchetto di dati contiene i vigneti situati su un pendio con una pendenza superiore al 30%. Per le superfici vengono indicati la coltura principale, la pendenza del pendio, la zona e l'azienda. Il set di dati con \"dati provvisori\" contiene informazioni relative all'anno solare in corso.",
-		"en": "This data set contains vineyard areas that are located on slopes with an inclination of more than 30%. The main crop, slope inclination, zone and farm are indicated for the areas. The dataset with \"provisional data\" contains information from the current calendar year."
-	  },
+      "dct:title": {
+        "de": "Flächenangaben zu Rebfächen in Hanglagen auf einem Betrieb in der Schweizer Landwirtschaft - Provisorische Daten",
+        "fr": "Indications de surface pour les vignobles en pente sur une exploitation agricole suisse - données provisoires",
+        "it": "Dati sulle superfici di vigneti in pendenza in un'azienda agricola svizzera - dati provvisori",
+        "en": "Information on the area of vineyards on slopes on a Swiss agricultural holding - provisional data"
+      },
+      "dct:description": {
+        "de": "Dieses Datenpaket enthält Rebflächen, die in einem Hang liegen mit einer Neigung grösser als 30%. Zu den Flächen wird die Hauptkultur, Hangneigung, Zone und Betrieb angegeben. Das Dataset mit \"provisorischen Daten\" enthält Angaben aus dem laufenden Kalenderjahr.",
+        "fr": "Ce paquet de données contient les vignobles situés sur des pentes dont l'inclinaison est supérieure à 30 %. La culture principale, l'inclinaison de la pente, la zone et l'exploitation sont indiquées pour les surfaces. L'ensemble de données contenant les « données provisoires » contient des informations sur l'année civile en cours.",
+        "it": "Questo pacchetto di dati contiene i vigneti situati su un pendio con una pendenza superiore al 30%. Per le superfici vengono indicati la coltura principale, la pendenza del pendio, la zona e l'azienda. Il set di dati con \"dati provvisori\" contiene informazioni relative all'anno solare in corso.",
+        "en": "This data set contains vineyard areas that are located on slopes with an inclination of more than 30%. The main crop, slope inclination, zone and farm are indicated for the areas. The dataset with \"provisional data\" contains information from the current calendar year."
+      },
       "adms:status": "published",
       "dct:modified": "2025-03-25",
       "dcat:accessURL": "https://www.blw.admin.ch/de/meine-agrardatenfreigabe",
       "dct:format": "CSV"
     }
-  ]
+  ],
+  "bv:externalCatalogs": null
 }

--- a/data/raw/datasets/e7b5cd7a-2e4f-48dd-ab78-0c4368220310.json
+++ b/data/raw/datasets/e7b5cd7a-2e4f-48dd-ab78-0c4368220310.json
@@ -13,7 +13,7 @@
     "it": "Il Registro delle denominazioni di origine (DOP) e delle indicazioni geografiche (IGP) consente di tutelare i nomi geografici e tradizionali che designano prodotti agricoli (ad eccezione del vino) la cui qualità e le cui caratteristiche principali sono determinate dalla loro origine. L'utilizzo di un nome protetto è appannaggio dei produttori della zona geografica definita che ottemperano ad un dettagliato elenco degli obblighi. La protezione di determinate denominazioni di prodotti agricoli è finalizzata a tutelare i consumatori dalle frodi e a proteggere i contadini dalla concorrenza sleale dovuta all'abuso delle denominazioni. La regolamentazione applicabile in questo settore permette il reciproco riconoscimento dei prodotti di qualità tra Svizzera e UE. Le DOP/IGP sono suddivise in quattro categorie: formaggi, prodotti carnei, prodotti vegetali e distillati. Attualmente il registro delle DOP/IGP conta 30 prodotti e il numero di registrazioni è in costante aumento."
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "info@blw.admin.ch",
     "schema:name": "info@blw.admin.ch"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "825146b2-b989-414a-93b8-a8a8acca7fff"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "protected-designation-of-origin",
@@ -166,6 +159,12 @@
       },
       "dct:license": "terms_by",
       "schema:comment": "ID for this distribution on opendata.swiss: 8ff0c82b-66f7-49f8-af88-5b5c3639a0b8"
+    }
+  ],
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "825146b2-b989-414a-93b8-a8a8acca7fff"
     }
   ]
 }

--- a/data/raw/datasets/e8c27678-45c6-42bd-a0a7-adce5a811f61.json
+++ b/data/raw/datasets/e8c27678-45c6-42bd-a0a7-adce5a811f61.json
@@ -14,7 +14,7 @@
     "it": "Quantità annue delle oleaginose al livello della produzione"
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "marktanalysen@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft, Fachbereich Marktanalysen"
@@ -26,13 +26,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "7f60af24-5112-4f2a-b702-4ca70eb48865"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "quantity",
@@ -80,5 +73,11 @@
   "dct:temporal": {
     "dcat:start_date": "2014-07-01",
     "dcat:end_date": "2023-07-01"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "7f60af24-5112-4f2a-b702-4ca70eb48865"
+    }
+  ]
 }

--- a/data/raw/datasets/ea33009b-6ee8-4db1-8b83-e40263dbb269.json
+++ b/data/raw/datasets/ea33009b-6ee8-4db1-8b83-e40263dbb269.json
@@ -13,7 +13,7 @@
     "it": "Prezzi medi mensili di latticini selezionati a livello della catena del valore commercio all'ingrosso/trasformazione"
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "marktanalysen@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft, Fachbereich Marktanalysen"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "3257332f-b970-46dd-a691-3d2949d68fe7"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "market-data",
@@ -78,5 +71,11 @@
   "dct:temporal": {
     "dcat:start_date": "2001-01-01",
     "dcat:end_date": "2025-01-01"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "3257332f-b970-46dd-a691-3d2949d68fe7"
+    }
+  ]
 }

--- a/data/raw/datasets/ee745f65-9f8d-45ac-939a-a6b894ad8b74.json
+++ b/data/raw/datasets/ee745f65-9f8d-45ac-939a-a6b894ad8b74.json
@@ -13,7 +13,7 @@
     "it": "Prezzi medi annui delle uova e di una selezione di prodotti a base di uova nella fase di consumo della catena del valore"
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "marktanalysen@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft, Fachbereich Marktanalysen"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "d734a47b-11b4-467a-aca9-7fb88ec5a058"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "market-data",
@@ -78,5 +71,11 @@
   "dct:temporal": {
     "dcat:start_date": "2011-01-01",
     "dcat:end_date": "2024-01-01"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "d734a47b-11b4-467a-aca9-7fb88ec5a058"
+    }
+  ]
 }

--- a/data/raw/datasets/efc52ea3-fa6c-4bcf-8de7-42126870f8de.json
+++ b/data/raw/datasets/efc52ea3-fa6c-4bcf-8de7-42126870f8de.json
@@ -13,7 +13,7 @@
     "it": "Prezzi medi annui per cereali panificabili, farina e prodotti da forno al livello del consumo"
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "marktanalysen@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft, Fachbereich Marktanalysen"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "532a5042-ff38-49ac-9748-ff3c99748581"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "market-data",
@@ -78,5 +71,11 @@
   "dct:temporal": {
     "dcat:start_date": "2020-01-01",
     "dcat:end_date": "2024-01-01"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "532a5042-ff38-49ac-9748-ff3c99748581"
+    }
+  ]
 }

--- a/data/raw/datasets/f0aba69d-4daf-412f-af1d-4e68898dada1.json
+++ b/data/raw/datasets/f0aba69d-4daf-412f-af1d-4e68898dada1.json
@@ -13,7 +13,7 @@
     "it": "Volumi annuali di latte crudo commercializzato a livello della catena del valore produzione"
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "marktanalysen@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft, Fachbereich Marktanalysen"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "5b1e77a6-a9cc-4364-af23-a5e12d3bf0b3"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "quantity",
@@ -78,5 +71,11 @@
   "dct:temporal": {
     "dcat:start_date": "2001-01-01",
     "dcat:end_date": "2024-01-01"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "5b1e77a6-a9cc-4364-af23-a5e12d3bf0b3"
+    }
+  ]
 }

--- a/data/raw/datasets/f2d347f7-7782-4411-b99e-666e67b6c652.json
+++ b/data/raw/datasets/f2d347f7-7782-4411-b99e-666e67b6c652.json
@@ -14,7 +14,7 @@
   },
   "dct:accessRights": "RESTRICTED",
   "dct:issued": "2020-01-01",
-  "dct:publisher": "BLW-OFAG-UFAG",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:name": "AV MAF, GRKDT",
     "schema:email": "maf@blw.admin.ch"
@@ -25,8 +25,8 @@
     "meine-agrardaten-freigabe",
     "MAF",
     "structural-data",
-	"crops",
-	"legal-form"
+    "crops",
+    "legal-form"
   ],
   "dct:accrualPeriodicity": "ANNUAL",
   "dct:modified": "2025-03-25",
@@ -44,19 +44,13 @@
   "foaf:page": [
     {
       "alias": "PDF: MAF-Verfügbare Datenpakete",
-	  "uri": "https://backend.blw.admin.ch/fileservice/sdweb-docs-prod-blwch-files/files/2024/08/28/3106f5f5-1bcb-4b25-a78a-75c712f2491f.pdf"
+      "uri": "https://backend.blw.admin.ch/fileservice/sdweb-docs-prod-blwch-files/files/2024/08/28/3106f5f5-1bcb-4b25-a78a-75c712f2491f.pdf"
     }
   ],
   "adms:status": "published",
   "bv:classification": "none",
   "bv:personalData": "personalData",
   "bv:typeOfData": "thematicData",
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": false
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "dcat:theme": [
     "agriculture"
   ],
@@ -67,41 +61,42 @@
   "dcat:distribution": [
     {
       "dct:identifier": "229be31f-e6d7-4017-9a3b-b5ffed71efe9",
-	  "dct:title": {
-		"de": "Flächenangaben zu Hauptkulturen auf einem Betrieb in der Schweizer Landwirtschaft",
-		"fr": "Données sur les surfaces des principales cultures dans une exploitation agricole suisse",
-		"it": "Dati sulle superfici delle principali colture in un'azienda agricola in Svizzera",
-		"en": "Area data for main crops on a farm in Swiss agriculture"
-	  },
-	  "dct:description": {
-		"de": "Dieses Datenpaket enthält die Fläche der im entsprechenden Jahr angebauten Hauptkulturen eines Betriebs inklusive Angabe zur landwirtschaftlichen Zone, Standortgemeinde und der Bewirtschaftungsform. Das Dataset enthält jährlich ab ca. Mitte März die Daten aus dem Vorjahr.",
-		"fr": "Ce paquet de données contient la surface des principales cultures d'une exploitation au cours de l'année concernée, y compris des informations sur la zone agricole, la commune d'implantation et le mode d'exploitation. L'ensemble de données contient chaque année, à partir de la mi-mars environ, les données de l'année précédente.",
-		"it": "Questo pacchetto di dati contiene la superficie delle colture principali di un'azienda coltivate nell'anno corrispondente, compresa l'indicazione della zona agricola, del comune di ubicazione e del tipo di gestione. Il set di dati contiene i dati dell'anno precedente a partire da circa metà marzo di ogni anno.",
-		"en": "This data package contains the area of the main crops grown on a holding in the corresponding year, including information on the agricultural zone, municipality and type of farming. The dataset contains data from the previous year, available annually from around mid-March."
-	  },
+      "dct:title": {
+        "de": "Flächenangaben zu Hauptkulturen auf einem Betrieb in der Schweizer Landwirtschaft",
+        "fr": "Données sur les surfaces des principales cultures dans une exploitation agricole suisse",
+        "it": "Dati sulle superfici delle principali colture in un'azienda agricola in Svizzera",
+        "en": "Area data for main crops on a farm in Swiss agriculture"
+      },
+      "dct:description": {
+        "de": "Dieses Datenpaket enthält die Fläche der im entsprechenden Jahr angebauten Hauptkulturen eines Betriebs inklusive Angabe zur landwirtschaftlichen Zone, Standortgemeinde und der Bewirtschaftungsform. Das Dataset enthält jährlich ab ca. Mitte März die Daten aus dem Vorjahr.",
+        "fr": "Ce paquet de données contient la surface des principales cultures d'une exploitation au cours de l'année concernée, y compris des informations sur la zone agricole, la commune d'implantation et le mode d'exploitation. L'ensemble de données contient chaque année, à partir de la mi-mars environ, les données de l'année précédente.",
+        "it": "Questo pacchetto di dati contiene la superficie delle colture principali di un'azienda coltivate nell'anno corrispondente, compresa l'indicazione della zona agricola, del comune di ubicazione e del tipo di gestione. Il set di dati contiene i dati dell'anno precedente a partire da circa metà marzo di ogni anno.",
+        "en": "This data package contains the area of the main crops grown on a holding in the corresponding year, including information on the agricultural zone, municipality and type of farming. The dataset contains data from the previous year, available annually from around mid-March."
+      },
       "adms:status": "published",
       "dct:modified": "2025-03-25",
       "dcat:accessURL": "https://www.blw.admin.ch/de/meine-agrardatenfreigabe",
       "dct:format": "CSV"
     },
-	{
+    {
       "dct:identifier": "0fbb5a05-2ed6-4fd8-bdd7-78e7e2b001cf",
-	  "dct:title": {
-		"de": "Flächenangaben zu Hauptkulturen auf einem Betrieb in der Schweizer Landwirtschaft - Provisorische Daten",
-		"fr": "Données sur les surfaces des principales cultures dans une exploitation agricole suisse - données provisoires",
-		"it": "Dati sulle superfici delle principali colture in un'azienda agricola in Svizzera - dati provvisori",
-		"en": "Area data for main crops on a farm in Swiss agriculture - provisional data"
-	  },
-	  "dct:description": {
-		"de": "Dieses Datenpaket enthält die Fläche der im entsprechenden Jahr angebauten Hauptkulturen eines Betriebs inklusive Angabe zur landwirtschaftlichen Zone, Standortgemeinde und der Bewirtschaftungsform. Das Dataset mit \"provisorischen Daten\" enthält Angaben aus dem laufenden Kalenderjahr.",
-		"fr": "Ce paquet de données contient la surface des principales cultures d'une exploitation au cours de l'année concernée, y compris des informations sur la zone agricole, la commune d'implantation et le mode d'exploitation. L'ensemble de données contenant les « données provisoires » contient des informations sur l'année civile en cours.",
-		"it": "Questo pacchetto di dati contiene la superficie delle colture principali di un'azienda coltivate nell'anno corrispondente, compresa l'indicazione della zona agricola, del comune di ubicazione e del tipo di gestione. Il set di dati con \"dati provvisori\" contiene informazioni relative all'anno solare in corso.",
-		"en": "This data package contains the area of the main crops grown on a holding in the corresponding year, including information on the agricultural zone, municipality and type of farming. The dataset with \"provisional data\" contains information from the current calendar year."
-	  },
+      "dct:title": {
+        "de": "Flächenangaben zu Hauptkulturen auf einem Betrieb in der Schweizer Landwirtschaft - Provisorische Daten",
+        "fr": "Données sur les surfaces des principales cultures dans une exploitation agricole suisse - données provisoires",
+        "it": "Dati sulle superfici delle principali colture in un'azienda agricola in Svizzera - dati provvisori",
+        "en": "Area data for main crops on a farm in Swiss agriculture - provisional data"
+      },
+      "dct:description": {
+        "de": "Dieses Datenpaket enthält die Fläche der im entsprechenden Jahr angebauten Hauptkulturen eines Betriebs inklusive Angabe zur landwirtschaftlichen Zone, Standortgemeinde und der Bewirtschaftungsform. Das Dataset mit \"provisorischen Daten\" enthält Angaben aus dem laufenden Kalenderjahr.",
+        "fr": "Ce paquet de données contient la surface des principales cultures d'une exploitation au cours de l'année concernée, y compris des informations sur la zone agricole, la commune d'implantation et le mode d'exploitation. L'ensemble de données contenant les « données provisoires » contient des informations sur l'année civile en cours.",
+        "it": "Questo pacchetto di dati contiene la superficie delle colture principali di un'azienda coltivate nell'anno corrispondente, compresa l'indicazione della zona agricola, del comune di ubicazione e del tipo di gestione. Il set di dati con \"dati provvisori\" contiene informazioni relative all'anno solare in corso.",
+        "en": "This data package contains the area of the main crops grown on a holding in the corresponding year, including information on the agricultural zone, municipality and type of farming. The dataset with \"provisional data\" contains information from the current calendar year."
+      },
       "adms:status": "published",
       "dct:modified": "2025-03-25",
       "dcat:accessURL": "https://www.blw.admin.ch/de/meine-agrardatenfreigabe",
       "dct:format": "CSV"
     }
-  ]
+  ],
+  "bv:externalCatalogs": null
 }

--- a/data/raw/datasets/f65f56fe-d007-4b28-b3eb-2da01cbb733b.json
+++ b/data/raw/datasets/f65f56fe-d007-4b28-b3eb-2da01cbb733b.json
@@ -13,7 +13,7 @@
     "it": "Per scheletro s'intende l'insieme dei frammenti minerali più grandi di 2 mm (resti nel setaccio). Individuati principalmente nei 50 cm superiori del profilo del suolo. (Dettagli: carta delle attitudini dei suoli svizzeri, marzo 1980)."
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "info@blw.admin.ch",
     "schema:name": "info@blw.admin.ch"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "d18a25f8-6967-41d7-8813-c4b1e486f54a"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "cultivation-suitability",
@@ -161,6 +154,12 @@
       },
       "dct:license": "terms_by",
       "schema:comment": "ID for this distribution on opendata.swiss: ecdeca9d-c614-4a72-94ee-3541c45a044a"
+    }
+  ],
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "d18a25f8-6967-41d7-8813-c4b1e486f54a"
     }
   ]
 }

--- a/data/raw/datasets/f684da8d-86dd-4d39-b17f-5414ae9b15d9.json
+++ b/data/raw/datasets/f684da8d-86dd-4d39-b17f-5414ae9b15d9.json
@@ -13,7 +13,7 @@
     "it": "Regioni dell’osservazione del mercato del latte e dei latticini sulla base delle quali sono pubblicati i prezzi alla produzione del latte. Le regioni sono definite nel seguente modo: Regione I: Ginevra, Vaud, Friburgo, Neuchâtel, Giura e parti del territorio francofono del Cantone di Berna (distretto amministrativo del Giura bernese). Regione II: Berna (tranne il distretto amministrativo del Giura bernese), Lucerna, Untervaldo (Sopraselva, Sottoselva), Uri, Zugo e una parte del Cantone di Svitto (distretti Svitto, Gersau e Küssnacht). Regione III: Basilea Campagna e Basilea Città, Argovia e Soletta. Regione IV: Zurigo, Sciaffusa, Turgovia, Appenzello (Interno ed Esterno), San Gallo, una parte del Cantone di Svitto (distretti Einsiedeln, March e Höfe), Glarona, Grigioni. Regione V: Vallese e Ticino."
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "info@blw.admin.ch",
     "schema:name": "info@blw.admin.ch"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "4e95ecac-0c7d-45b5-bfec-844504a7aa69"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "statistical-units",
@@ -159,6 +152,12 @@
       },
       "dct:license": "terms_by",
       "schema:comment": "ID for this distribution on opendata.swiss: c7ea8405-2a71-4e1e-91ee-edcf6efda432"
+    }
+  ],
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "4e95ecac-0c7d-45b5-bfec-844504a7aa69"
     }
   ]
 }

--- a/data/raw/datasets/fae110b0-eb93-4b47-9440-dbdecfb8c452.json
+++ b/data/raw/datasets/fae110b0-eb93-4b47-9440-dbdecfb8c452.json
@@ -14,7 +14,7 @@
     "it": "Prezzi medi annui e prezzi indicativi delle oleaginose al livello della produzione"
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "marktanalysen@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft, Fachbereich Marktanalysen"
@@ -26,13 +26,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "985819da-067a-4d87-a0d9-861f75655ced"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "price",
@@ -80,5 +73,11 @@
   "dct:temporal": {
     "dcat:start_date": "2017-07-01",
     "dcat:end_date": "2023-07-01"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "985819da-067a-4d87-a0d9-861f75655ced"
+    }
+  ]
 }

--- a/data/raw/datasets/fc928f44-f690-4280-ad53-d14bf5f80138.json
+++ b/data/raw/datasets/fc928f44-f690-4280-ad53-d14bf5f80138.json
@@ -13,7 +13,7 @@
     "it": ""
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "alessandro.rossi@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "b37cdbf6-8c04-4c7b-a2b8-7c85b6c07993"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [],
   "dcat:theme": [
@@ -114,5 +107,11 @@
   "dct:temporal": {
     "dcat:start_date": "1990-01-01",
     "dcat:end_date": "2015-12-31"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "b37cdbf6-8c04-4c7b-a2b8-7c85b6c07993"
+    }
+  ]
 }

--- a/data/raw/datasets/fca78318-4077-480b-977f-beea2d6732fd.json
+++ b/data/raw/datasets/fca78318-4077-480b-977f-beea2d6732fd.json
@@ -13,7 +13,7 @@
     "it": "Quantità annue delle piante proteiche al livello della produzione"
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "marktanalysen@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft, Fachbereich Marktanalysen"
@@ -25,13 +25,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "9569ebd8-9611-4276-91d0-c3c872fe3c7f"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "quantity",
@@ -78,5 +71,11 @@
   "dct:temporal": {
     "dcat:start_date": "2014-07-01",
     "dcat:end_date": "2023-07-01"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "9569ebd8-9611-4276-91d0-c3c872fe3c7f"
+    }
+  ]
 }

--- a/data/raw/datasets/fee0fa24-5a7a-4ee1-a2b4-ec0780339b4f.json
+++ b/data/raw/datasets/fee0fa24-5a7a-4ee1-a2b4-ec0780339b4f.json
@@ -14,7 +14,7 @@
     "it": "Quantità annue dei mangimi al livello della produzione"
   },
   "dct:accessRights": "PUBLIC",
-  "dct:publisher": "Bundesamt für Landwirtschaft BLW",
+  "dct:publisher": "BLW-OFAG-UFAG-FOAG",
   "dcat:contactPoint": {
     "schema:email": "marktanalysen@blw.admin.ch",
     "schema:name": "Bundesamt für Landwirtschaft, Fachbereich Marktanalysen"
@@ -26,13 +26,6 @@
   "bv:classification": "none",
   "bv:personalData": "none",
   "bv:archivalValue": false,
-  "bv:opendata_swiss": {
-    "bv:mustBePublished": true,
-    "dct:identifier": "10015a2a-933b-43d9-bb42-c4aa28d7884e"
-  },
-  "bv:i14y": {
-    "bv:mustBePublished": true
-  },
   "bv:typeOfData": "thematicData",
   "dcat:keyword": [
     "market-data",
@@ -80,5 +73,11 @@
   "dct:temporal": {
     "dcat:start_date": "2014-07-01",
     "dcat:end_date": "2023-07-01"
-  }
+  },
+  "bv:externalCatalogs": [
+    {
+      "dcat:catalog": "opendata.swiss",
+      "dct:identifier": "10015a2a-933b-43d9-bb42-c4aa28d7884e"
+    }
+  ]
 }

--- a/data/schemas/dataService.json
+++ b/data/schemas/dataService.json
@@ -134,14 +134,14 @@
             "description": "URL of the technical endpoint of the data service."
         },
         "dcat:landingPage": {
-          "title": "Landing page",
-          "type": [
-              "string",
-              "null"
-          ],
-          "format": "uri",
-          "description": "Landing page or homepage for the API."
-      },
+            "title": "Landing page",
+            "type": [
+                "string",
+                "null"
+            ],
+            "format": "uri",
+            "description": "Landing page or homepage for the API."
+        },
         "adms:status": {
             "title": "Status",
             "type": "string",
@@ -252,41 +252,48 @@
             "title": "Applicable legislation",
             "description": "The legislation that mandates or allows the creation or management of the data service.",
             "type": [
-              "array",
-              "null"
+                "array",
+                "null"
             ],
             "items": {
-              "title": "URI",
-              "type": [
-                  "string",
-                  "null"
-              ],
-              "format": "uri"
+                "title": "URI",
+                "type": [
+                    "string",
+                    "null"
+                ],
+                "format": "uri"
             }
         },
         "bv:externalCatalogs": {
             "title": "External catalogs",
-            "type": "object",
-	        "required": [
-		        "dcat:catalog"
-	        ],
+            "type": [
+                "array",
+                "null"
+            ],
             "description": "External catalogs where the data object is published",
-	        "properties": {
-		        "dcat:catalog": {
-			        "type": "string",
-			        "title": "Reference to external catalog",
-			        "description": "Reference to the external catalogs the data object should be pubished to. Adding a catalog here triggers metadata validation and an automatic push to the listed catalog.",
-			        "enum": [
-				        "",
-				        "I14Y"
-			        ]
-		        },
-		        "dct:identifier": {
-			        "type": "string",
-			        "title": "ID in the external catalog"
-			        "description": "This field should be automatically filled at first publication with the ID assigned by the external catalog. It is a hidden field in the edit form."
-		        }
-	        }
+            "items": {
+                "type": "object",
+                "required": [
+                    "dcat:catalog"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                    "dcat:catalog": {
+                        "type": "string",
+                        "title": "Reference to external catalog",
+                        "description": "Reference to the external catalogs the data object should be pubished to. Adding a catalog here triggers metadata validation and an automatic push to the listed catalog.",
+                        "enum": [
+                            "",
+                            "I14Y"
+                        ]
+                    },
+                    "dct:identifier": {
+                        "type": "string",
+                        "title": "ID in the external catalog",
+                        "description": "This field should be automatically filled at first publication with the ID assigned by the external catalog. It is a hidden field in the edit form."
+                    }
+                }
+            }
         }
     }
 }

--- a/data/schemas/dataService.json
+++ b/data/schemas/dataService.json
@@ -264,32 +264,29 @@
               "format": "uri"
             }
         },
-        "bv:i14y": {
+        "bv:externalCatalogs": {
+            "title": "External catalogs",
             "type": "object",
-            "required": [
-                "bv:mustBePublished"
-            ],
-            "title": "I14Y publication",
-            "description": "Indicates if the data service metadata must be made available via the interoperability platform I14Y. Optionally references the I14Y publication ID.",
-            "properties": {
-                "bv:mustBePublished": {
-                    "title": "I14Y publication flag",
-                    "description": "Indicates if the data service must be published on I14Y. May be used by harvesters or automatic metadata publication. This is true by default.",
-                    "type": "boolean",
-                    "default": true
-                },
-                "dct:identifier": {
-                    "title": "I14Y identifier",
-                    "type": "string",
-                    "description": "Identifier for the data service on I14Y."
-                },
-                "dcat:accessURL": {
-                    "title": "I14Y URL",
-                    "type": "string",
-                    "format": "uri",
-                    "description": "URL for the data service on I14Y"
-                }
-            }
+	        "required": [
+		        "dcat:catalog"
+	        ],
+            "description": "External catalogs where the data object is published",
+	        "properties": {
+		        "dcat:catalog": {
+			        "type": "string",
+			        "title": "Reference to external catalog",
+			        "description": "Reference to the external catalogs the data object should be pubished to. Adding a catalog here triggers metadata validation and an automatic push to the listed catalog.",
+			        "enum": [
+				        "",
+				        "I14Y"
+			        ]
+		        },
+		        "dct:identifier": {
+			        "type": "string",
+			        "title": "ID in the external catalog"
+			        "description": "This field should be automatically filled at first publication with the ID assigned by the external catalog. It is a hidden field in the edit form."
+		        }
+	        }
         }
     }
 }

--- a/data/schemas/dataset.json
+++ b/data/schemas/dataset.json
@@ -299,29 +299,36 @@
         },
         "bv:externalCatalogs": {
             "title": "External catalogs",
-            "type": "object",
-	        "required": [
-		        "dcat:catalog"
-	        ],
+            "type": [
+                "array",
+                "null"
+            ],
             "description": "External catalogs where the data object is published",
-	        "properties": {
-		        "dcat:catalog": {
-			        "type": "string",
-			        "title": "Reference to external catalog",
-			        "description": "Reference to the external catalogs the data object should be pubished to. Adding a catalog here triggers metadata validation and an automatic push to the listed catalog.",
-			        "enum": [
-				        "",
-				        "I14Y",
-				        "opendata.swiss",
-				        "geocat.ch"
-			        ]
-		        },
-		        "dct:identifier": {
-			        "type": "string",
-			        "title": "ID in the external catalog"
-			        "description": "This field should be automatically filled at first publication with the ID assigned by the external catalog. It is a hidden field in the edit form."
-		        }
-	        }
+            "items": {
+                "type": "object",
+                "required": [
+                    "dcat:catalog"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                    "dcat:catalog": {
+                        "type": "string",
+                        "title": "Reference to external catalog",
+                        "description": "Reference to the external catalogs the data object should be pubished to. Adding a catalog here triggers metadata validation and an automatic push to the listed catalog.",
+                        "enum": [
+                            "",
+                            "I14Y",
+                            "opendata.swiss",
+                            "geocat.ch"
+                        ]
+                    },
+                    "dct:identifier": {
+                        "type": "string",
+                        "title": "ID in the external catalog",
+                        "description": "This field should be automatically filled at first publication with the ID assigned by the external catalog. It is a hidden field in the edit form."
+                    }
+                }
+            }
         },
         "dcat:theme": {
             "type": [
@@ -700,7 +707,15 @@
                 "it": "Esempio di descrizione. La descrizione di un dataset può essere decisamente più lunga di un titolo, ma deve rimanere chiara (3-10 frasi). Descrivi il dataset, non il tema, né un sistema informatico, né il tuo settore. Puoi parlare del contenuto del dataset, dello scopo, ecc.",
                 "en": "Example description. The description of a dataset can be significantly longer than a title, but it should remain comprehensible (3-10 sentences). Describe the dataset, not the topic, an IT system, or your field. You may discuss the content of the dataset, its purpose, etc."
             },
-            "dcat:keyword": ["some-keywords", "all-english", "separated-by-dashes", "digiFLUX", "FOAG", "eCH", "DigiAgriFoodCH"],
+            "dcat:keyword": [
+                "some-keywords",
+                "all-english",
+                "separated-by-dashes",
+                "digiFLUX",
+                "FOAG",
+                "eCH",
+                "DigiAgriFoodCH"
+            ],
             "dct:accessRights": "PUBLIC",
             "dct:publisher": "BLW-OFAG-UFAG-FOAG",
             "dcat:contactPoint": {

--- a/data/schemas/dataset.json
+++ b/data/schemas/dataset.json
@@ -297,58 +297,31 @@
             "title": "Archival value",
             "description": "Indicates if this dataset has archival value and must be sent to the BAR."
         },
-        "bv:opendata_swiss": {
+        "bv:externalCatalogs": {
+            "title": "External catalogs",
             "type": "object",
-            "required": [
-                "bv:mustBePublished"
-            ],
-            "title": "opendataswiss publication",
-            "description": "Indicates if the dataset must be published as Open Government Data (OGD) via the opendata.swiss portal. Optionally references the opendata.swiss publication ID.",
-            "properties": {
-                "bv:mustBePublished": {
-                    "title": "opendata.swiss publication flag",
-                    "description": "Indicates if the dataset must be published on opendata.swiss. May be used by harvesters or automatic metadata publication.",
-                    "type": "boolean"
-                },
-                "dct:identifier": {
-                    "title": "opendata.swiss identifier",
-                    "type": "string",
-                    "description": "Identifier for the dataset on opendata.swiss."
-                },
-                "dcat:accessURL": {
-                    "title": "opendata.swiss URL",
-                    "type": "string",
-                    "format": "uri",
-                    "description": "URL for the dataset on opendata.swiss"
-                }
-            }
-        },
-        "bv:i14y": {
-            "type": "object",
-            "required": [
-                "bv:mustBePublished"
-            ],
-            "title": "i14y publication",
-            "description": "Indicates if the dataset metadata must be made available via the interoperability platform I14Y. Optionally references the I14Y publication ID.",
-            "properties": {
-                "bv:mustBePublished": {
-                    "title": "i14y publication flag",
-                    "description": "Indicates if the dataset must be published on I14Y. May be used by harvesters or automatic metadata publication. This is true by default.",
-                    "type": "boolean",
-                    "default": true
-                },
-                "dct:identifier": {
-                    "title": "i14y identifier",
-                    "type": "string",
-                    "description": "Identifier for the dataset on I14Y."
-                },
-                "dcat:accessURL": {
-                    "title": "i14y url",
-                    "type": "string",
-                    "format": "uri",
-                    "description": "URL for the dataset on I14Y"
-                }
-            }
+	        "required": [
+		        "dcat:catalog"
+	        ],
+            "description": "External catalogs where the data object is published",
+	        "properties": {
+		        "dcat:catalog": {
+			        "type": "string",
+			        "title": "Reference to external catalog",
+			        "description": "Reference to the external catalogs the data object should be pubished to. Adding a catalog here triggers metadata validation and an automatic push to the listed catalog.",
+			        "enum": [
+				        "",
+				        "I14Y",
+				        "opendata.swiss",
+				        "geocat.ch"
+			        ]
+		        },
+		        "dct:identifier": {
+			        "type": "string",
+			        "title": "ID in the external catalog"
+			        "description": "This field should be automatically filled at first publication with the ID assigned by the external catalog. It is a hidden field in the edit form."
+		        }
+	        }
         },
         "dcat:theme": {
             "type": [

--- a/data/schemas/dataset.json
+++ b/data/schemas/dataset.json
@@ -17,9 +17,7 @@
         "adms:status",
         "bv:classification",
         "bv:personalData",
-        "bv:archivalValue",
-        "bv:opendata_swiss",
-        "bv:i14y"
+        "bv:archivalValue"
     ],
     "properties": {
         "schema:image": {


### PR DESCRIPTION
This fixes #11 by building a generic catalog object with an enum of possible catalogs. In the same object there is an attribute to store the external ID for API-requests purposes.

This makes the handling of external catalogs more flexible, but kind of misuses the dcat:catalog property.

THIS IS A VALIDITY BREAKING CHANGE.

- [x] Metadata should be bulk-adapted to the new structure
- [x] The form shoud be adapted to the new structure