### PR TITLE
Add pattern to titles

### DIFF
--- a/data/schemas/catalog.json
+++ b/data/schemas/catalog.json
@@ -37,18 +37,22 @@
             "properties": {
                 "de": {
                     "type": "string",
+                    "pattern": "[a-zA-Z0-9_\\-\\s]{10,75}",
                     "title": "Deutsch"
                 },
                 "fr": {
                     "type": "string",
+                    "pattern": "[a-zA-Z0-9_\\-\\s]{10,75}",
                     "title": "Français"
                 },
                 "it": {
                     "type": "string",
+                    "pattern": "[a-zA-Z0-9_\\-\\s]{10,75}",
                     "title": "Italiano"
                 },
                 "en": {
                     "type": "string",
+                    "pattern": "[a-zA-Z0-9_\\-\\s]{10,75}",
                     "title": "English"
                 }
             }

--- a/data/schemas/dataService.json
+++ b/data/schemas/dataService.json
@@ -39,18 +39,22 @@
             "properties": {
                 "de": {
                     "type": "string",
+                    "pattern": "[a-zA-Z0-9_\\-\\s]{10,75}",
                     "title": "Deutsch"
                 },
                 "fr": {
                     "type": "string",
+                    "pattern": "[a-zA-Z0-9_\\-\\s]{10,75}",
                     "title": "Français"
                 },
                 "it": {
                     "type": "string",
+                    "pattern": "[a-zA-Z0-9_\\-\\s]{10,75}",
                     "title": "Italiano"
                 },
                 "en": {
                     "type": "string",
+                    "pattern": "[a-zA-Z0-9_\\-\\s]{10,75}",
                     "title": "English"
                 }
             }

--- a/data/schemas/dataset.json
+++ b/data/schemas/dataset.json
@@ -45,18 +45,22 @@
             "properties": {
                 "de": {
                     "type": "string",
+                    "pattern": "[a-zA-Z0-9_\\-\\s]{10,75}",
                     "title": "Deutsch"
                 },
                 "fr": {
                     "type": "string",
+                    "pattern": "[a-zA-Z0-9_\\-\\s]{10,75}",
                     "title": "Français"
                 },
                 "it": {
                     "type": "string",
+                    "pattern": "[a-zA-Z0-9_\\-\\s]{10,75}",
                     "title": "Italiano"
                 },
                 "en": {
                     "type": "string",
+                    "pattern": "[a-zA-Z0-9_\\-\\s]{10,75}",
                     "title": "English"
                 }
             }
@@ -620,18 +624,22 @@
                         "properties": {
                             "de": {
                                 "type": "string",
+                                "pattern": "[a-zA-Z0-9_\\-\\s]{10,75}",
                                 "title": "Deutsch"
                             },
                             "fr": {
                                 "type": "string",
+                                "pattern": "[a-zA-Z0-9_\\-\\s]{10,75}",
                                 "title": "Français"
                             },
                             "it": {
                                 "type": "string",
+                                "pattern": "[a-zA-Z0-9_\\-\\s]{10,75}",
                                 "title": "Italiano"
                             },
                             "en": {
                                 "type": "string",
+                                "pattern": "[a-zA-Z0-9_\\-\\s]{10,75}",
                                 "title": "English"
                             }
                         }

--- a/data/schemas/datasetSeries.json
+++ b/data/schemas/datasetSeries.json
@@ -40,18 +40,22 @@
             "properties": {
                 "de": {
                     "type": "string",
+                    "pattern": "[a-zA-Z0-9_\\-\\s]{10,75}",
                     "title": "Deutsch"
                 },
                 "fr": {
                     "type": "string",
+                    "pattern": "[a-zA-Z0-9_\\-\\s]{10,75}",
                     "title": "Français"
                 },
                 "it": {
                     "type": "string",
+                    "pattern": "[a-zA-Z0-9_\\-\\s]{10,75}",
                     "title": "Italiano"
                 },
                 "en": {
                     "type": "string",
+                    "pattern": "[a-zA-Z0-9_\\-\\s]{10,75}",
                     "title": "English"
                 }
             }


### PR DESCRIPTION
This PR integrates a regex expression for the tiles in all classes:

"pattern": "[a-zA-Z0-9_\\-\\s]{10,75}",

The pattern only allows upper and lower characters, digits, whitespaces and dashes ("-"), with a minimum lenght of 10 and a maximum of 75 characters