### PR TITLE
Remove emptyString publisher

### DIFF
--- a/data/schemas/catalog.json
+++ b/data/schemas/catalog.json
@@ -85,7 +85,6 @@
             "type": "string",
             "description": "Federal Office responsible for the data object",
             "enum": [
-                "",
                 "BLW-OFAG-UFAG-FOAG",
                 "BLV-OSAV-USAV-FSVO",
                 "BFS-OFS-UST-FSO",


### PR DESCRIPTION
A filled "publisher" is needed for the catalog to work correcly.
It also makes sense that this information is always available at the time of metadata creation, so it should not be a big issue.