### PR TITLE
Security patches

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiohappyeyeballs==2.6.1
-aiohttp==3.13.2
+aiohttp>=3.13.4
 aiosignal==1.4.0
 altair==5.5.0
 annotated-types==0.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,7 +48,7 @@ packaging==25.0
 pandas==2.3.3
 parso==0.8.5
 pexpect==4.9.0
-pillow==11.3.0
+pillow>=12.1.1
 platformdirs==4.4.0
 pluggy==1.6.0
 prompt_toolkit==3.0.52

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ cycler==0.12.1
 debugpy==1.8.16
 decorator==5.2.1
 executing==2.2.1
-fonttools==4.59.2
+fonttools>=4.60.2
 frozenlist==1.8.0
 gitdb==4.0.12
 GitPython==3.1.45

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,7 @@ platformdirs==4.4.0
 pluggy==1.6.0
 prompt_toolkit==3.0.52
 propcache==0.4.1
-protobuf==6.32.0
+protobuf>=6.33.5
 psutil==7.0.0
 ptyprocess==0.7.0
 pure_eval==0.2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -90,7 +90,7 @@ traitlets==5.14.3
 typing-inspection==0.4.2
 typing_extensions==4.14.1
 tzdata==2025.2
-urllib3==2.5.0
+urllib3>=2.6.3
 watchdog==6.0.0
 wcwidth==0.2.13
 webencodings==0.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -85,7 +85,7 @@ stack-data==0.6.3
 streamlit==1.51.0
 tenacity==9.1.2
 toml==0.10.2
-tornado==6.5.2
+tornado>=6.5.5
 traitlets==5.14.3
 typing-inspection==0.4.2
 typing_extensions==4.14.1


### PR DESCRIPTION
- Update urllib3 version to >=2.6.3
- Update tornado version requirement to >=6.5.5
- Update pillow version to >=12.1.1
- Update aiohttp version to >=3.13.4
- Update fonttools version to >=4.60.2
- Update protobuf version to >=6.33.5